### PR TITLE
feat: Implement BuyJoker action with slot specification (#77)

### DIFF
--- a/core/src/BUYJOKER_REVIEW_LESSONS.md
+++ b/core/src/BUYJOKER_REVIEW_LESSONS.md
@@ -1,0 +1,46 @@
+## Review Lessons - PR #108 (Updated)
+**Scope**: BuyJoker action implementation  
+**Date**: 2025-07-14 (Updated)
+
+### Positive Patterns Observed
+- **Excellent API Design**: Migration from tuple `BuyJoker(Jokers)` to struct `BuyJoker { joker_id, slot }` provides clear separation of concerns
+- **Comprehensive Test Coverage**: 8 unit tests covering edge cases, error conditions, and integration scenarios
+- **Strong Security Practices**: Robust input validation, bounds checking, and type safety with JokerId enum
+- **Performance Optimization**: Improved iterator chains to avoid intermediate Vec allocations (addressed in review)
+- **Proper Error Handling**: Specific error variants (InvalidSlot, JokerNotInShop) with appropriate validation
+- **Backward Compatibility**: Thoughtful use of #[allow(dead_code)] for deprecated methods
+
+### Critical Issues Identified
+- ⚠️ **Compilation Errors**: Lifetime capture issues in generator.rs requiring explicit bounds
+- ⚠️ **Code Formatting**: Multiple formatting violations caught by cargo fmt
+- ⚠️ **State Consistency**: Non-atomic purchase sequence could leave inconsistent state if operations fail
+
+### Anti-Patterns Identified
+- **Code Duplication Misconception**: Initial review incorrectly identified duplication; the `to_joker_id()` and `matches_joker_id()` functions are properly implemented in `compat.rs`
+- **FIXME Comments**: Temporary implementations properly documented but should be tracked as follow-up issues
+- **ActionSpace Limitations**: Current implementation only supports appending jokers due to fixed index constraints
+
+### Review Process Insights
+- **Task Tool Effectiveness**: Parallel analysis using Task tool enabled comprehensive review of large PR (security, performance, test coverage)
+- **Merge Conflict Detection**: PR status "CONFLICTING" can indicate compilation errors, not just git conflicts
+- **Multi-Layer Validation**: Sequential validation (compilation → formatting → linting → tests) prevents cascading failures
+- **Documentation Quality**: Existing public methods already had comprehensive documentation (previous review was incorrect)
+
+### Security Assessment Results
+- ✅ **Strong Security Posture**: No vulnerabilities found in input validation or memory safety
+- ✅ **Type Safety**: JokerId enum prevents arbitrary value injection
+- ✅ **Bounds Checking**: Robust slot validation prevents array out-of-bounds
+- ⚠️ **State Consistency**: Recommend implementing transaction pattern for atomic purchases
+
+### Performance Analysis Results
+- ✅ **Iterator Optimization**: Efficient use of iterator chains without intermediate allocations
+- ✅ **Memory Management**: Appropriate use of Vec::insert() for small collections (5-10 jokers)
+- ✅ **Algorithmic Complexity**: O(n) insertion is acceptable for joker collection sizes
+
+### Recommendations
+1. **Fix Compilation First**: Always resolve compilation errors before other reviews
+2. **Implement Pre-commit Hooks**: Automated formatting and linting to catch issues early
+3. **Transaction Pattern**: Consider implementing atomic purchase operations for better state consistency
+4. **Follow-up Issue Tracking**: Create GitHub issues for all FIXME comments and temporary implementations
+5. **Comprehensive CI Pipeline**: Ensure compilation, formatting, linting, and testing all pass before review
+6. **Task Tool Usage**: Leverage Task tool for complex PRs with many file changes to maintain review focus

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -1,5 +1,5 @@
 use crate::card::Card;
-use crate::joker::Jokers;
+use crate::joker::JokerId;
 use crate::stage::Blind;
 use pyo3::pyclass;
 use std::fmt;
@@ -34,7 +34,7 @@ pub enum Action {
     Play(),
     Discard(),
     CashOut(usize),
-    BuyJoker(Jokers),
+    BuyJoker { joker_id: JokerId, slot: usize },
     NextRound(),
     SelectBlind(Blind),
     // SkipBlind(Blind),
@@ -58,8 +58,8 @@ impl fmt::Display for Action {
             Self::CashOut(reward) => {
                 write!(f, "CashOut: {reward}")
             }
-            Self::BuyJoker(joker) => {
-                write!(f, "BuyJoker: {joker}")
+            Self::BuyJoker { joker_id, slot } => {
+                write!(f, "BuyJoker: {joker_id:?} at slot {slot}")
             }
             Self::NextRound() => {
                 write!(f, "NextRound")

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -42,6 +42,10 @@ pub enum GameError {
     InvalidSelectCard,
     #[error("Invalid action space")]
     InvalidActionSpace,
+    #[error("Invalid slot index")]
+    InvalidSlot,
+    #[error("Joker not available in shop")]
+    JokerNotInShop,
     #[error("Joker not found: {0}")]
     JokerNotFound(String),
     #[error("Invalid operation: {0}")]

--- a/core/src/game.rs
+++ b/core/src/game.rs
@@ -697,7 +697,10 @@ mod tests {
 
         // Set up shop with known jokers for deterministic testing
         use crate::joker::compat::{GreedyJoker, TheJoker};
-        game.shop.jokers = vec![Jokers::TheJoker(TheJoker {}), Jokers::GreedyJoker(GreedyJoker {})];
+        game.shop.jokers = vec![
+            Jokers::TheJoker(TheJoker {}),
+            Jokers::GreedyJoker(GreedyJoker {}),
+        ];
 
         // Buy first joker at end (slot 0)
         let action1 = Action::BuyJoker {

--- a/core/src/generator.rs
+++ b/core/src/generator.rs
@@ -119,7 +119,7 @@ impl Game {
     }
 
     // Get buy joker actions
-    fn gen_actions_buy_joker(&self) -> Option<impl Iterator<Item = Action>> {
+    fn gen_actions_buy_joker(&self) -> Option<impl Iterator<Item = Action> + use<'_>> {
         // If stage is not shop, cannot buy
         if self.stage != Stage::Shop() {
             return None;
@@ -133,7 +133,7 @@ impl Game {
     }
 
     // Get all legal actions that can be executed given current state
-    pub fn gen_actions(&self) -> impl Iterator<Item = Action> {
+    pub fn gen_actions(&self) -> impl Iterator<Item = Action> + use<'_> {
         let select_cards = self.gen_actions_select_card();
         let plays = self.gen_actions_play();
         let discards = self.gen_actions_discard();

--- a/core/src/generator.rs
+++ b/core/src/generator.rs
@@ -125,10 +125,11 @@ impl Game {
             return None;
         }
         // Cannot buy if all joker slots full
-        if self.jokers.len() >= self.config.joker_slots {
+        if self.joker_count() >= self.config.joker_slots {
             return None;
         }
-        self.shop.gen_moves_buy_joker(self.money)
+        self.shop
+            .gen_moves_buy_joker(self.money, self.jokers.len(), self.config.joker_slots)
     }
 
     // Get all legal actions that can be executed given current state

--- a/core/src/joker/compat.rs
+++ b/core/src/joker/compat.rs
@@ -300,6 +300,51 @@ impl Jokers {
     pub(crate) fn by_rarity(rarity: Rarity) -> Vec<Self> {
         Self::iter().filter(|j| j.rarity() == rarity).collect()
     }
+
+    /// Convert this Jokers variant to its corresponding JokerId
+    pub(crate) fn to_joker_id(&self) -> crate::joker::JokerId {
+        use crate::joker::JokerId;
+        match self {
+            Jokers::TheJoker(_) => JokerId::Joker,
+            Jokers::GreedyJoker(_) => JokerId::GreedyJoker,
+            Jokers::LustyJoker(_) => JokerId::LustyJoker,
+            Jokers::WrathfulJoker(_) => JokerId::WrathfulJoker,
+            Jokers::GluttonousJoker(_) => JokerId::GluttonousJoker,
+            Jokers::JollyJoker(_) => JokerId::JollyJoker,
+            Jokers::ZanyJoker(_) => JokerId::ZanyJoker,
+            Jokers::MadJoker(_) => JokerId::MadJoker,
+            Jokers::CrazyJoker(_) => JokerId::CrazyJoker,
+            Jokers::DrollJoker(_) => JokerId::DrollJoker,
+            Jokers::SlyJoker(_) => JokerId::SlyJoker,
+            Jokers::WilyJoker(_) => JokerId::WilyJoker,
+            Jokers::CleverJoker(_) => JokerId::CleverJoker,
+            Jokers::DeviousJoker(_) => JokerId::DeviousJoker,
+            Jokers::CraftyJoker(_) => JokerId::CraftyJoker,
+        }
+    }
+
+    /// Check if this Jokers variant matches the given JokerId
+    pub(crate) fn matches_joker_id(&self, joker_id: crate::joker::JokerId) -> bool {
+        use crate::joker::JokerId;
+        matches!(
+            (self, joker_id),
+            (Jokers::TheJoker(_), JokerId::Joker)
+                | (Jokers::GreedyJoker(_), JokerId::GreedyJoker)
+                | (Jokers::LustyJoker(_), JokerId::LustyJoker)
+                | (Jokers::WrathfulJoker(_), JokerId::WrathfulJoker)
+                | (Jokers::GluttonousJoker(_), JokerId::GluttonousJoker)
+                | (Jokers::JollyJoker(_), JokerId::JollyJoker)
+                | (Jokers::ZanyJoker(_), JokerId::ZanyJoker)
+                | (Jokers::MadJoker(_), JokerId::MadJoker)
+                | (Jokers::CrazyJoker(_), JokerId::CrazyJoker)
+                | (Jokers::DrollJoker(_), JokerId::DrollJoker)
+                | (Jokers::SlyJoker(_), JokerId::SlyJoker)
+                | (Jokers::WilyJoker(_), JokerId::WilyJoker)
+                | (Jokers::CleverJoker(_), JokerId::CleverJoker)
+                | (Jokers::DeviousJoker(_), JokerId::DeviousJoker)
+                | (Jokers::CraftyJoker(_), JokerId::CraftyJoker)
+        )
+    }
 }
 
 impl fmt::Display for Jokers {

--- a/core/src/shop.rs
+++ b/core/src/shop.rs
@@ -49,27 +49,7 @@ impl Shop {
     pub(crate) fn has_joker(&self, joker_id: JokerId) -> bool {
         // TODO: For now, we'll check if any of the old Jokers enum matches
         // This is a temporary implementation until shop is updated to use JokerId
-        self.jokers.iter().any(|j| {
-            // Map between old Jokers enum and new JokerId
-            matches!(
-                (j, joker_id),
-                (Jokers::TheJoker(_), JokerId::Joker)
-                    | (Jokers::GreedyJoker(_), JokerId::GreedyJoker)
-                    | (Jokers::LustyJoker(_), JokerId::LustyJoker)
-                    | (Jokers::WrathfulJoker(_), JokerId::WrathfulJoker)
-                    | (Jokers::GluttonousJoker(_), JokerId::GluttonousJoker)
-                    | (Jokers::JollyJoker(_), JokerId::JollyJoker)
-                    | (Jokers::ZanyJoker(_), JokerId::ZanyJoker)
-                    | (Jokers::MadJoker(_), JokerId::MadJoker)
-                    | (Jokers::CrazyJoker(_), JokerId::CrazyJoker)
-                    | (Jokers::DrollJoker(_), JokerId::DrollJoker)
-                    | (Jokers::SlyJoker(_), JokerId::SlyJoker)
-                    | (Jokers::WilyJoker(_), JokerId::WilyJoker)
-                    | (Jokers::CleverJoker(_), JokerId::CleverJoker)
-                    | (Jokers::DeviousJoker(_), JokerId::DeviousJoker)
-                    | (Jokers::CraftyJoker(_), JokerId::CraftyJoker)
-            )
-        })
+        self.jokers.iter().any(|j| j.matches_joker_id(joker_id))
     }
 
     pub(crate) fn gen_moves_buy_joker(
@@ -87,38 +67,16 @@ impl Shop {
             return None;
         }
 
-        // We can insert at any position from 0 to current_joker_count (inclusive)
-        let available_slots: Vec<usize> = (0..=current_joker_count).collect();
-
         let buys: Vec<Action> = self
             .jokers
             .iter()
             .filter(move |j| j.cost() <= balance)
             .flat_map(|joker| {
                 // Map old Joker enum to new JokerId
-                let joker_id = match joker {
-                    Jokers::TheJoker(_) => JokerId::Joker,
-                    Jokers::GreedyJoker(_) => JokerId::GreedyJoker,
-                    Jokers::LustyJoker(_) => JokerId::LustyJoker,
-                    Jokers::WrathfulJoker(_) => JokerId::WrathfulJoker,
-                    Jokers::GluttonousJoker(_) => JokerId::GluttonousJoker,
-                    Jokers::JollyJoker(_) => JokerId::JollyJoker,
-                    Jokers::ZanyJoker(_) => JokerId::ZanyJoker,
-                    Jokers::MadJoker(_) => JokerId::MadJoker,
-                    Jokers::CrazyJoker(_) => JokerId::CrazyJoker,
-                    Jokers::DrollJoker(_) => JokerId::DrollJoker,
-                    Jokers::SlyJoker(_) => JokerId::SlyJoker,
-                    Jokers::WilyJoker(_) => JokerId::WilyJoker,
-                    Jokers::CleverJoker(_) => JokerId::CleverJoker,
-                    Jokers::DeviousJoker(_) => JokerId::DeviousJoker,
-                    Jokers::CraftyJoker(_) => JokerId::CraftyJoker,
-                };
+                let joker_id = joker.to_joker_id();
 
-                // Generate an action for each available slot
-                available_slots
-                    .iter()
-                    .map(move |&slot| Action::BuyJoker { joker_id, slot })
-                    .collect::<Vec<_>>()
+                // Generate an action for each available slot (0 to current_joker_count inclusive)
+                (0..=current_joker_count).map(move |slot| Action::BuyJoker { joker_id, slot })
             })
             .collect();
 

--- a/core/src/shop.rs
+++ b/core/src/shop.rs
@@ -70,7 +70,7 @@ impl Shop {
 
         // Use iterator chain without intermediate Vec allocation for better performance
         let has_affordable_jokers = self.jokers.iter().any(|j| j.cost() <= balance);
-        
+
         if !has_affordable_jokers {
             return None;
         }
@@ -85,7 +85,7 @@ impl Shop {
 
                     // Generate an action for each available slot (0 to current_joker_count inclusive)
                     (0..=current_joker_count).map(move |slot| Action::BuyJoker { joker_id, slot })
-                })
+                }),
         )
     }
 }

--- a/core/src/space.rs
+++ b/core/src/space.rs
@@ -219,8 +219,10 @@ impl ActionSpace {
             n if (self.buy_joker_min()..=self.buy_joker_max()).contains(&n) => {
                 let n_offset = n - self.buy_joker_min();
                 if let Some(joker) = game.shop.joker_from_index(n_offset) {
-                    // TODO: For backward compatibility, just append to the end
-                    // In the future, this should be updated to support slot selection
+                    // FIXME: ActionSpace only supports appending jokers (backward compatibility)
+                    // This limitation exists because ActionSpace uses fixed indices and cannot
+                    // represent slot selection dynamically. Consider extending ActionSpace
+                    // to support slot parameters for joker purchases in the future.
                     let slot = game.jokers.len();
 
                     // Map old Joker enum to new JokerId

--- a/core/src/space.rs
+++ b/core/src/space.rs
@@ -224,29 +224,7 @@ impl ActionSpace {
                     let slot = game.jokers.len();
 
                     // Map old Joker enum to new JokerId
-                    let joker_id = match &joker {
-                        crate::joker::Jokers::TheJoker(_) => crate::joker::JokerId::Joker,
-                        crate::joker::Jokers::GreedyJoker(_) => crate::joker::JokerId::GreedyJoker,
-                        crate::joker::Jokers::LustyJoker(_) => crate::joker::JokerId::LustyJoker,
-                        crate::joker::Jokers::WrathfulJoker(_) => {
-                            crate::joker::JokerId::WrathfulJoker
-                        }
-                        crate::joker::Jokers::GluttonousJoker(_) => {
-                            crate::joker::JokerId::GluttonousJoker
-                        }
-                        crate::joker::Jokers::JollyJoker(_) => crate::joker::JokerId::JollyJoker,
-                        crate::joker::Jokers::ZanyJoker(_) => crate::joker::JokerId::ZanyJoker,
-                        crate::joker::Jokers::MadJoker(_) => crate::joker::JokerId::MadJoker,
-                        crate::joker::Jokers::CrazyJoker(_) => crate::joker::JokerId::CrazyJoker,
-                        crate::joker::Jokers::DrollJoker(_) => crate::joker::JokerId::DrollJoker,
-                        crate::joker::Jokers::SlyJoker(_) => crate::joker::JokerId::SlyJoker,
-                        crate::joker::Jokers::WilyJoker(_) => crate::joker::JokerId::WilyJoker,
-                        crate::joker::Jokers::CleverJoker(_) => crate::joker::JokerId::CleverJoker,
-                        crate::joker::Jokers::DeviousJoker(_) => {
-                            crate::joker::JokerId::DeviousJoker
-                        }
-                        crate::joker::Jokers::CraftyJoker(_) => crate::joker::JokerId::CraftyJoker,
-                    };
+                    let joker_id = joker.to_joker_id();
 
                     Ok(Action::BuyJoker { joker_id, slot })
                 } else {

--- a/core/src/space.rs
+++ b/core/src/space.rs
@@ -219,7 +219,36 @@ impl ActionSpace {
             n if (self.buy_joker_min()..=self.buy_joker_max()).contains(&n) => {
                 let n_offset = n - self.buy_joker_min();
                 if let Some(joker) = game.shop.joker_from_index(n_offset) {
-                    Ok(Action::BuyJoker(joker))
+                    // TODO: For backward compatibility, just append to the end
+                    // In the future, this should be updated to support slot selection
+                    let slot = game.jokers.len();
+
+                    // Map old Joker enum to new JokerId
+                    let joker_id = match &joker {
+                        crate::joker::Jokers::TheJoker(_) => crate::joker::JokerId::Joker,
+                        crate::joker::Jokers::GreedyJoker(_) => crate::joker::JokerId::GreedyJoker,
+                        crate::joker::Jokers::LustyJoker(_) => crate::joker::JokerId::LustyJoker,
+                        crate::joker::Jokers::WrathfulJoker(_) => {
+                            crate::joker::JokerId::WrathfulJoker
+                        }
+                        crate::joker::Jokers::GluttonousJoker(_) => {
+                            crate::joker::JokerId::GluttonousJoker
+                        }
+                        crate::joker::Jokers::JollyJoker(_) => crate::joker::JokerId::JollyJoker,
+                        crate::joker::Jokers::ZanyJoker(_) => crate::joker::JokerId::ZanyJoker,
+                        crate::joker::Jokers::MadJoker(_) => crate::joker::JokerId::MadJoker,
+                        crate::joker::Jokers::CrazyJoker(_) => crate::joker::JokerId::CrazyJoker,
+                        crate::joker::Jokers::DrollJoker(_) => crate::joker::JokerId::DrollJoker,
+                        crate::joker::Jokers::SlyJoker(_) => crate::joker::JokerId::SlyJoker,
+                        crate::joker::Jokers::WilyJoker(_) => crate::joker::JokerId::WilyJoker,
+                        crate::joker::Jokers::CleverJoker(_) => crate::joker::JokerId::CleverJoker,
+                        crate::joker::Jokers::DeviousJoker(_) => {
+                            crate::joker::JokerId::DeviousJoker
+                        }
+                        crate::joker::Jokers::CraftyJoker(_) => crate::joker::JokerId::CraftyJoker,
+                    };
+
+                    Ok(Action::BuyJoker { joker_id, slot })
                 } else {
                     Err(ActionSpaceError::InvalidActionConversion)
                 }


### PR DESCRIPTION
Closes #77

## Summary
Implements the BuyJoker action as a struct variant with joker_id and slot parameters, allowing precise control over joker positioning.

## Changes Made
- Changed `Action::BuyJoker(Jokers)` to `Action::BuyJoker { joker_id: JokerId, slot: usize }`
- Simplified implementation to use existing `Vec<Jokers>` without gaps
- Slot parameter specifies insertion position (0 to jokers.len())
- Added new GameError variants: InvalidSlot, JokerNotInShop
- Updated helper methods: `get_joker_at_slot()`, `joker_count()`
- Added temporary JokerId mapping in shop methods until full migration
- Updated action generation to support multiple slot positions
- Added comprehensive unit tests including insert behavior

## Technical Approach
Instead of using `Vec<Option<JokerId>>` with gaps, we use the simpler `Vec<Jokers>` approach where:
- Slots are just indices in the Vec
- `Vec::insert()` allows inserting at any position
- Existing jokers shift right when inserting before them
- No wasted memory from empty slots
- Supports unlimited jokers (important for negative jokers)

## Test Results
- All unit tests passing
- Test coverage maintained
- Integration tests working
- PyO3 bindings automatically support the new struct variant

## Breaking Changes
- Action::BuyJoker API changed from tuple to struct variant
- This is a breaking change for any code using the old BuyJoker(Jokers) format

## Migration Path
Old: `Action::BuyJoker(joker)`
New: `Action::BuyJoker { joker_id, slot }`