### PR TITLE
🚨 HOTFIX: Fix CI formatting failures on main branch

### DIFF
--- a/core/src/static_joker.rs
+++ b/core/src/static_joker.rs
@@ -423,7 +423,8 @@ mod tests {
 
     #[test]
     fn test_suit_jokers_wrathful() {
-        let joker = crate::static_joker_factory::StaticJokerFactory::create_wrathful_joker_concrete();
+        let joker =
+            crate::static_joker_factory::StaticJokerFactory::create_wrathful_joker_concrete();
 
         // Test properties
         assert_eq!(joker.id(), JokerId::WrathfulJoker);
@@ -445,7 +446,8 @@ mod tests {
 
     #[test]
     fn test_suit_jokers_gluttonous() {
-        let joker = crate::static_joker_factory::StaticJokerFactory::create_gluttonous_joker_concrete();
+        let joker =
+            crate::static_joker_factory::StaticJokerFactory::create_gluttonous_joker_concrete();
 
         // Test properties
         assert_eq!(joker.id(), JokerId::GluttonousJoker);
@@ -468,10 +470,13 @@ mod tests {
     #[test]
     fn test_suit_jokers_isolation() {
         // Create all four suit jokers
-        let greedy = crate::static_joker_factory::StaticJokerFactory::create_greedy_joker_concrete();
+        let greedy =
+            crate::static_joker_factory::StaticJokerFactory::create_greedy_joker_concrete();
         let lusty = crate::static_joker_factory::StaticJokerFactory::create_lusty_joker_concrete();
-        let wrathful = crate::static_joker_factory::StaticJokerFactory::create_wrathful_joker_concrete();
-        let gluttonous = crate::static_joker_factory::StaticJokerFactory::create_gluttonous_joker_concrete();
+        let wrathful =
+            crate::static_joker_factory::StaticJokerFactory::create_wrathful_joker_concrete();
+        let gluttonous =
+            crate::static_joker_factory::StaticJokerFactory::create_gluttonous_joker_concrete();
 
         // Create one card of each suit
         let diamond_card = Card::new(Value::Ace, Suit::Diamond);

--- a/core/src/static_joker_factory.rs
+++ b/core/src/static_joker_factory.rs
@@ -338,7 +338,7 @@ impl StaticJokerFactory {
             .expect("Valid joker configuration"),
         )
     }
-    
+
     /// Test-only methods that return concrete types for internal testing
     #[cfg(test)]
     pub fn create_greedy_joker_concrete() -> StaticJoker {


### PR DESCRIPTION
## Summary
Fixes critical CI formatting failures on main branch caused by rustfmt violations.

## Changes Made
- ✅ **Fixed long line formatting** in `core/src/static_joker.rs` 
  - Split long factory method calls across multiple lines to meet rustfmt requirements
  - Affected test methods: `test_suit_jokers_wrathful`, `test_suit_jokers_gluttonous`, `test_suit_jokers_isolation`
- ✅ **Removed trailing whitespace** in `core/src/static_joker_factory.rs`
  - Clean up whitespace issues in factory implementation

## Test Results
- ✅ **Formatting**: `cargo fmt --all -- --check` passes
- ✅ **Build**: `cargo build --all --verbose` succeeds  
- ✅ **Check**: `cargo check --all --verbose` passes
- ✅ **CI Ready**: All pre-commit checks passing locally

## Priority
🚨 **CRITICAL** - This blocks all CI workflows on main branch

## Note
This PR was recreated from a clean main branch to contain only formatting fixes.
The original PR #130 included unrelated changes from other feature branches.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>