### PR TITLE
🚨 HOTFIX: Fix clippy warnings causing CI failures

### DIFF
--- a/core/examples/new_joker_api.rs
+++ b/core/examples/new_joker_api.rs
@@ -20,7 +20,7 @@ fn main() {
 
     // Example 3: Getting jokers by rarity
     let common_jokers = JokerFactory::get_by_rarity(JokerRarity::Common);
-    println!("\nCommon jokers available: {:?}", common_jokers);
+    println!("\nCommon jokers available: {common_jokers:?}");
 
     // Example 4: Demonstrating JokerEffect
     let effect = JokerEffect::new().with_mult(4).with_chips(50);

--- a/core/src/generator.rs
+++ b/core/src/generator.rs
@@ -285,8 +285,10 @@ mod tests {
         let ace = Card::new(Value::Ace, Suit::Heart);
         let king = Card::new(Value::King, Suit::Diamond);
 
-        let mut g = Game::default();
-        g.stage = Stage::Blind(Blind::Small);
+        let mut g = Game {
+            stage: Stage::Blind(Blind::Small),
+            ..Default::default()
+        };
 
         // nothing selected, nothing to play
         assert!(g.gen_actions_discard().is_none());
@@ -308,8 +310,10 @@ mod tests {
         let ace = Card::new(Value::Ace, Suit::Heart);
         let king = Card::new(Value::King, Suit::Diamond);
 
-        let mut g = Game::default();
-        g.stage = Stage::Blind(Blind::Small);
+        let mut g = Game {
+            stage: Stage::Blind(Blind::Small),
+            ..Default::default()
+        };
 
         // nothing selected, nothing to discard
         assert!(g.gen_actions_discard().is_none());
@@ -406,8 +410,10 @@ mod tests {
 
     #[test]
     fn test_unmask_action_space_move_cards() {
-        let mut g = Game::default();
-        g.stage = Stage::Blind(Blind::Small);
+        let mut g = Game {
+            stage: Stage::Blind(Blind::Small),
+            ..Default::default()
+        };
         let mut space = ActionSpace::from(g.config.clone());
 
         // Default action space everything should be masked, since no cards available yet

--- a/core/src/joker/compat.rs
+++ b/core/src/joker/compat.rs
@@ -372,8 +372,10 @@ mod tests {
     use super::*;
 
     fn score_before_after_joker(joker: Jokers, hand: SelectHand, before: usize, after: usize) {
-        let mut g = Game::default();
-        g.stage = Stage::Blind(Blind::Small);
+        let mut g = Game {
+            stage: Stage::Blind(Blind::Small),
+            ..Default::default()
+        };
 
         // First score without joker
         let score = g.calc_score(hand.best_hand().unwrap());

--- a/core/src/joker/conditional.rs
+++ b/core/src/joker/conditional.rs
@@ -456,8 +456,8 @@ mod tests {
 
         // We'll test these conditions using a mock context in integration tests
         // For now, just verify they can be created and formatted
-        assert_eq!(format!("{:?}", less_than_100), "MoneyLessThan(100)");
-        assert_eq!(format!("{:?}", greater_than_25), "MoneyGreaterThan(25)");
+        assert_eq!(format!("{less_than_100:?}"), "MoneyLessThan(100)");
+        assert_eq!(format!("{greater_than_25:?}"), "MoneyGreaterThan(25)");
     }
 
     #[test]
@@ -469,11 +469,11 @@ mod tests {
         let size_two = JokerCondition::HandSizeExactly(2);
         let played_flush = JokerCondition::PlayedHandType(HandRank::Flush);
 
-        assert_eq!(format!("{:?}", no_face), "NoFaceCardsHeld");
-        assert_eq!(format!("{:?}", contains_king), "ContainsRank(King)");
-        assert_eq!(format!("{:?}", contains_heart), "ContainsSuit(Heart)");
-        assert_eq!(format!("{:?}", size_two), "HandSizeExactly(2)");
-        assert_eq!(format!("{:?}", played_flush), "PlayedHandType(Flush)");
+        assert_eq!(format!("{no_face:?}"), "NoFaceCardsHeld");
+        assert_eq!(format!("{contains_king:?}"), "ContainsRank(King)");
+        assert_eq!(format!("{contains_heart:?}"), "ContainsSuit(Heart)");
+        assert_eq!(format!("{size_two:?}"), "HandSizeExactly(2)");
+        assert_eq!(format!("{played_flush:?}"), "PlayedHandType(Flush)");
     }
 
     #[test]
@@ -492,13 +492,13 @@ mod tests {
         let not_condition = JokerCondition::Not(Box::new(JokerCondition::Always));
 
         // Test formatting
-        assert!(format!("{:?}", all_condition).contains("All"));
-        assert!(format!("{:?}", any_condition).contains("Any"));
-        assert!(format!("{:?}", not_condition).contains("Not"));
+        assert!(format!("{all_condition:?}").contains("All"));
+        assert!(format!("{any_condition:?}").contains("Any"));
+        assert!(format!("{not_condition:?}").contains("Not"));
 
         // Test Always condition
         let always = JokerCondition::Always;
-        assert_eq!(format!("{:?}", always), "Always");
+        assert_eq!(format!("{always:?}"), "Always");
     }
 
     #[test]
@@ -520,12 +520,14 @@ mod tests {
 
     // Mock GameContext for testing - contains only the fields we need to test
     #[derive(Debug)]
+    #[allow(dead_code)]
     struct MockGameContext {
         pub money: i32,
         pub chips: i32,
         pub mult: i32,
     }
 
+    #[allow(dead_code)]
     impl MockGameContext {
         fn new(money: i32) -> Self {
             Self {

--- a/core/src/joker/hand_composition_tests.rs
+++ b/core/src/joker/hand_composition_tests.rs
@@ -8,7 +8,6 @@ use crate::{
 /// - Ride the Bus: +1 mult per hand without face card
 /// - Blackboard: X3 mult if all held cards same suit/rank  
 /// - DNA: copy first card if only 1 in hand
-
 #[cfg(test)]
 mod ride_the_bus_tests {
     use super::*;

--- a/core/src/static_joker_factory.rs
+++ b/core/src/static_joker_factory.rs
@@ -411,7 +411,6 @@ impl StaticJokerFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::joker::Joker;
 
     #[test]
     fn test_basic_joker_creation() {

--- a/core/tests/dependency_docs_test.rs
+++ b/core/tests/dependency_docs_test.rs
@@ -62,9 +62,8 @@ fn all_dependencies_are_justified() {
 
     for dep in dependencies {
         assert!(
-            content.contains(&format!("### {}", dep)),
-            "Dependency '{}' must have a justification section",
-            dep
+            content.contains(&format!("### {dep}")),
+            "Dependency '{dep}' must have a justification section"
         );
     }
 }
@@ -76,7 +75,7 @@ fn pyo3_version_is_secure() {
 
     for file in cargo_files {
         if Path::new(file).exists() {
-            let content = fs::read_to_string(file).expect(&format!("Failed to read {}", file));
+            let content = fs::read_to_string(file).unwrap_or_else(|_| panic!("Failed to read {file}"));
 
             if content.contains("pyo3") {
                 // Check that pyo3 version is at least 0.24.1
@@ -88,8 +87,7 @@ fn pyo3_version_is_secure() {
                     content.contains("version = \"0.24") ||
                     content.contains("version = \"0.25") ||
                     content.contains("version = \"1."),
-                    "pyo3 version must be at least 0.24.1 to address RUSTSEC-2025-0020 vulnerability in {}",
-                    file
+                    "pyo3 version must be at least 0.24.1 to address RUSTSEC-2025-0020 vulnerability in {file}"
                 );
             }
         }

--- a/core/tests/pyo3_test.rs
+++ b/core/tests/pyo3_test.rs
@@ -15,8 +15,8 @@ fn test_pyclass_types_exist() {
     // Test that Action enum works with PyO3
     let action = Action::Play();
     match action {
-        Action::Play() => assert!(true),
-        _ => assert!(false),
+        Action::Play() => (), // Expected case
+        _ => panic!("Expected Action::Play()"),
     }
 
     // Test that Stage enum works


### PR DESCRIPTION
## Summary
Fixes critical CI clippy failures caused by code quality warnings being treated as errors.

## Issues Fixed

### 🔧 **Assertion Patterns** 
- Fixed `assert\!(true)` and `assert\!(false)` in `core/tests/pyo3_test.rs`
- Replaced with proper pattern matching and `panic\!()` calls

### 🔧 **Format String Optimization**
- Fixed `uninlined_format_args` warnings across multiple files
- Updated format strings to use direct variable interpolation (`{var:?}` instead of `{:?}, var`)
- Affected files: `new_joker_api.rs`, `dependency_docs_test.rs`, `conditional.rs`

### 🔧 **Function Call Patterns**
- Fixed `expect_fun_call` warnings in `dependency_docs_test.rs`
- Replaced `.expect(&format\!(...))` with `.unwrap_or_else( < /dev/null | _| panic!(...))`

### 🔧 **Documentation Style**
- Fixed `empty_line_after_doc_comments` in `hand_composition_tests.rs`
- Removed unnecessary empty line after doc comment

### 🔧 **Dead Code Management**
- Removed unused import in `static_joker_factory.rs`
- Added `#[allow(dead_code)]` for test utilities in `conditional.rs`

### 🔧 **Initialization Patterns**
- Fixed `field_reassign_with_default` warnings in `generator.rs` and `compat.rs`
- Used struct update syntax: `Game { stage: ..., ..Default::default() }`

## Test Results
- ✅ **Clippy**: `cargo clippy --all --all-targets -- -D warnings` passes
- ✅ **Formatting**: `cargo fmt --all -- --check` passes  
- ✅ **Build**: `cargo build --all` succeeds

## Priority
🚨 **CRITICAL** - This resolves clippy failures blocking CI workflows

## CI Impact
The CI workflow runs `cargo clippy --all -- -D warnings` which treats all warnings as hard errors. These fixes ensure the clippy job passes.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>