### PR TITLE
🚨 HOTFIX: Fix formatting regression causing CI failures

### DIFF
--- a/core/tests/dependency_docs_test.rs
+++ b/core/tests/dependency_docs_test.rs
@@ -75,7 +75,8 @@ fn pyo3_version_is_secure() {
 
     for file in cargo_files {
         if Path::new(file).exists() {
-            let content = fs::read_to_string(file).unwrap_or_else(|_| panic!("Failed to read {file}"));
+            let content =
+                fs::read_to_string(file).unwrap_or_else(|_| panic!("Failed to read {file}"));
 
             if content.contains("pyo3") {
                 // Check that pyo3 version is at least 0.24.1


### PR DESCRIPTION
## Summary
Fixes formatting regression introduced in PR #132 that caused CI failures.

## Issue
The clippy fix in PR #132 changed a line in `dependency_docs_test.rs:78` that is now too long for rustfmt, causing the CI formatting check to fail.

## Fix
- Split the long `unwrap_or_else` call across multiple lines
- Maintains the clippy fix while satisfying rustfmt requirements

## Before (Failing)
```rust
let content = fs::read_to_string(file).unwrap_or_else( < /dev/null | _| panic!("Failed to read {file}"));
```

## After (Passing)  
```rust
let content =
    fs::read_to_string(file).unwrap_or_else(|_| panic!("Failed to read {file}"));
```

## Test Results
- ✅ **Formatting**: `cargo fmt --all -- --check` passes
- ✅ **Clippy**: `cargo clippy --all -- -D warnings` passes  
- ✅ **Build**: `cargo build --all` succeeds

## Priority
🚨 **CRITICAL** - This resolves CI formatting failures blocking workflows

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>