### PR TITLE
🚨 HOTFIX: Fix feature gating for PyO3 to resolve CI test failures

### DIFF
--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -1,6 +1,7 @@
 use crate::card::Card;
 use crate::joker::JokerId;
 use crate::stage::Blind;
+#[cfg(feature = "python")]
 use pyo3::pyclass;
 use std::fmt;
 

--- a/core/src/card.rs
+++ b/core/src/card.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "colored")]
 use colored::Colorize;
+#[cfg(feature = "python")]
 use pyo3::pyclass;
 use std::{
     fmt,

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 const DEFAULT_ROUND_START: usize = 0;

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "python")]
 use pyo3::exceptions::PyException;
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 use thiserror::Error;
 

--- a/core/src/hand.rs
+++ b/core/src/hand.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use itertools::Itertools;
+#[cfg(feature = "python")]
 use pyo3::pyclass;
 use std::fmt;
 

--- a/core/src/joker/compat.rs
+++ b/core/src/joker/compat.rs
@@ -3,6 +3,7 @@ use crate::effect::Effects;
 use crate::game::Game;
 use crate::hand::MadeHand;
 use crate::joker::{Categories, Joker as NewJoker, JokerRarity as Rarity};
+#[cfg(feature = "python")]
 use pyo3::pyclass;
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/core/src/joker/mod.rs
+++ b/core/src/joker/mod.rs
@@ -1,6 +1,7 @@
 use crate::card::Card;
 use crate::hand::{Hand, SelectHand};
 use crate::stage::Stage;
+#[cfg(feature = "python")]
 use pyo3::pyclass;
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/core/src/space.rs
+++ b/core/src/space.rs
@@ -3,6 +3,7 @@ use crate::config::Config;
 use crate::error::ActionSpaceError;
 use crate::game::Game;
 use crate::stage::Blind;
+#[cfg(feature = "python")]
 use pyo3::pyclass;
 
 // Hard code a bounded action space.


### PR DESCRIPTION
## Summary
Fixes critical CI test failures by adding proper feature gating for PyO3 imports, allowing tests to run without Python dependencies.

## Root Cause
The code was importing `pyo3` modules without proper `#[cfg(feature = "python")]` feature gates, causing:
1. **Compilation failures** when `python` feature disabled
2. **CI test failures** due to Python library linking issues
3. **Local development issues** with Python version mismatches

## Fix Applied
Added `#[cfg(feature = "python")]` guards to all PyO3 imports in:

### Files Fixed
- ✅ `core/src/action.rs:4` - `use pyo3::pyclass;`
- ✅ `core/src/config.rs:1` - `use pyo3::prelude::*;`
- ✅ `core/src/error.rs:1,2` - PyO3 exception and prelude imports
- ✅ `core/src/card.rs:3` - `use pyo3::pyclass;`
- ✅ `core/src/hand.rs:3` - `use pyo3::pyclass;`  
- ✅ `core/src/space.rs:6` - `use pyo3::pyclass;`
- ✅ `core/src/joker/mod.rs:4` - `use pyo3::pyclass;`
- ✅ `core/src/joker/compat.rs:6` - `use pyo3::pyclass;`

## Test Results
### ✅ **Feature Gating Fixed**
- **No Python**: `cargo test -p balatro-rs --no-default-features --features serde` ✅ **RUNS**
- **With Python**: `cargo test -p balatro-rs --features "python,serde"` ✅ **COMPILES** 
- **CLI**: `cargo test -p balatro-cli` ✅ **RUNS**

### 📋 **Test Status**
- 158 tests passed, 9 failed with **actual code issues** (not infrastructure)
- Test failures are now **real bugs to fix**, not CI configuration problems

## CI Impact
This resolves the primary CI test failures by:
- ✅ Allowing tests to run without Python library dependencies
- ✅ Fixing compilation when `python` feature is disabled
- ✅ Maintaining compatibility with Python bindings when enabled

## Next Steps
The 9 remaining test failures are actual code bugs that should be addressed separately:
- `game::tests::test_buy_joker_expanded_slots` - Game logic issue
- `static_joker::tests::*` - Configuration and string matching issues

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>