### PR TITLE
🐛 Fix: Static joker configuration validation issues (#136)

### DIFF
--- a/core/src/hand.rs
+++ b/core/src/hand.rs
@@ -225,6 +225,26 @@ impl SelectHand {
         if self.len() < 1 {
             return None;
         }
+
+        // High card means no pairs, flushes, straights, etc.
+        // Check that no higher-ranking hands are present
+        if self.is_pair().is_some()
+            || self.is_two_pair().is_some()
+            || self.is_three_of_kind().is_some()
+            || self.is_straight().is_some()
+            || self.is_flush().is_some()
+            || self.is_fullhouse().is_some()
+            || self.is_four_of_kind().is_some()
+            || self.is_straight_flush().is_some()
+            || self.is_royal_flush().is_some()
+            || self.is_five_of_kind().is_some()
+            || self.is_flush_house().is_some()
+            || self.is_flush_five().is_some()
+        {
+            return None;
+        }
+
+        // If no higher hands, return the highest card
         if let Some((_value, cards)) = self
             .values_freq()
             .into_iter()

--- a/core/src/static_joker.rs
+++ b/core/src/static_joker.rs
@@ -556,6 +556,7 @@ mod tests {
         let joker = StaticJoker::builder(JokerId::Joker, "Expensive", "Costs more")
             .rarity(JokerRarity::Common)
             .cost(10)
+            .mult(1) // Add minimal bonus to satisfy validation
             .build()
             .expect("Valid joker configuration");
 
@@ -567,6 +568,7 @@ mod tests {
         // Common
         let common = StaticJoker::builder(JokerId::Joker, "Common", "")
             .rarity(JokerRarity::Common)
+            .mult(1) // Add minimal bonus to satisfy validation
             .build()
             .expect("Valid joker configuration");
         assert_eq!(common.cost(), 3);
@@ -574,6 +576,7 @@ mod tests {
         // Uncommon
         let uncommon = StaticJoker::builder(JokerId::Joker, "Uncommon", "")
             .rarity(JokerRarity::Uncommon)
+            .mult(1) // Add minimal bonus to satisfy validation
             .build()
             .expect("Valid joker configuration");
         assert_eq!(uncommon.cost(), 6);
@@ -581,6 +584,7 @@ mod tests {
         // Rare
         let rare = StaticJoker::builder(JokerId::Joker, "Rare", "")
             .rarity(JokerRarity::Rare)
+            .mult(1) // Add minimal bonus to satisfy validation
             .build()
             .expect("Valid joker configuration");
         assert_eq!(rare.cost(), 8);
@@ -588,6 +592,7 @@ mod tests {
         // Legendary
         let legendary = StaticJoker::builder(JokerId::Joker, "Legendary", "")
             .rarity(JokerRarity::Legendary)
+            .mult(1) // Add minimal bonus to satisfy validation
             .build()
             .expect("Valid joker configuration");
         assert_eq!(legendary.cost(), 20);


### PR DESCRIPTION
## Summary
Fixes three failing tests in static joker implementation by resolving configuration validation logic and high card condition bugs.

## Changes Made
### 1. **Fixed Configuration Validation Logic** 
- **Issue**: Tests `test_cost_override` and `test_default_costs` were failing because they created jokers without any bonuses
- **Root Cause**: `StaticJoker::builder()` validation requires at least one bonus (chips, mult, or mult_multiplier)
- **Solution**: Added minimal `.mult(1)` bonus to test jokers to satisfy validation while preserving test intent
- **Files**: `core/src/static_joker.rs`

### 2. **Fixed High Card Condition Logic**
- **Issue**: `test_high_card_condition` was failing because `is_highcard()` incorrectly returned true for hands containing pairs
- **Root Cause**: Original logic only checked for non-empty hands, not the absence of higher-ranking hands
- **Solution**: Implemented proper high card detection that verifies NO higher-ranking hands (pairs, flushes, straights, etc.) exist
- **Files**: `core/src/hand.rs`

## Test Results
- ✅ `static_joker::tests::test_cost_override` - Now passes
- ✅ `static_joker::tests::test_default_costs` - Now passes  
- ✅ `static_joker::tests::test_high_card_condition` - Now passes

All tests run with `cargo test --no-default-features --features serde` to avoid Python dependency issues.

## Pre-commit Checks
- ✅ `cargo fmt` - Code formatting applied
- ✅ `cargo clippy --all -- -D warnings` - No linting warnings

## Breaking Changes
None - changes are internal test fixes and bug corrections.

## Validation
```bash
cd core && cargo test test_cost_override test_default_costs test_high_card_condition --no-default-features --features serde
```

Closes #136

🤖 Generated with [Claude Code](https://claude.ai/code)