### PR TITLE
Fix #138: Inconsistent string formatting in joker descriptions

### DIFF
--- a/core/src/static_joker_factory.rs
+++ b/core/src/static_joker_factory.rs
@@ -92,13 +92,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Jolly Joker (+8 Mult if played hand contains a Pair)
+    /// Create Jolly Joker (+8 Mult if played hand contains Pair)
     pub fn create_jolly_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::JollyJoker,
                 "Jolly Joker",
-                "+8 Mult if played hand contains a Pair",
+                "+8 Mult if played hand contains Pair",
             )
             .rarity(JokerRarity::Common)
             .cost(3)
@@ -110,13 +110,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Zany Joker (+12 Mult if played hand contains a Three of a Kind)
+    /// Create Zany Joker (+12 Mult if played hand contains Three of a Kind)
     pub fn create_zany_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::ZanyJoker,
                 "Zany Joker",
-                "+12 Mult if played hand contains a Three of a Kind",
+                "+12 Mult if played hand contains Three of a Kind",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -128,13 +128,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Mad Joker (+10 Mult if played hand contains a Two Pair)
+    /// Create Mad Joker (+10 Mult if played hand contains Two Pair)
     pub fn create_mad_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::MadJoker,
                 "Mad Joker",
-                "+10 Mult if played hand contains a Two Pair",
+                "+10 Mult if played hand contains Two Pair",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -146,13 +146,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Crazy Joker (+12 Mult if played hand contains a Straight)
+    /// Create Crazy Joker (+12 Mult if played hand contains Straight)
     pub fn create_crazy_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::CrazyJoker,
                 "Crazy Joker",
-                "+12 Mult if played hand contains a Straight",
+                "+12 Mult if played hand contains Straight",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -164,13 +164,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Droll Joker (+10 Mult if played hand contains a Flush)
+    /// Create Droll Joker (+10 Mult if played hand contains Flush)
     pub fn create_droll_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::DrollJoker,
                 "Droll Joker",
-                "+10 Mult if played hand contains a Flush",
+                "+10 Mult if played hand contains Flush",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -182,13 +182,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Sly Joker (+50 Chips if played hand contains a Pair)
+    /// Create Sly Joker (+50 Chips if played hand contains Pair)
     pub fn create_sly_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::SlyJoker,
                 "Sly Joker",
-                "+50 Chips if played hand contains a Pair",
+                "+50 Chips if played hand contains Pair",
             )
             .rarity(JokerRarity::Common)
             .cost(3)
@@ -200,13 +200,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Wily Joker (+100 Chips if played hand contains a Three of a Kind)
+    /// Create Wily Joker (+100 Chips if played hand contains Three of a Kind)
     pub fn create_wily_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::WilyJoker,
                 "Wily Joker",
-                "+100 Chips if played hand contains a Three of a Kind",
+                "+100 Chips if played hand contains Three of a Kind",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -218,13 +218,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Clever Joker (+80 Chips if played hand contains a Two Pair)
+    /// Create Clever Joker (+80 Chips if played hand contains Two Pair)
     pub fn create_clever_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::CleverJoker,
                 "Clever Joker",
-                "+80 Chips if played hand contains a Two Pair",
+                "+80 Chips if played hand contains Two Pair",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -236,13 +236,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Devious Joker (+100 Chips if played hand contains a Straight)
+    /// Create Devious Joker (+100 Chips if played hand contains Straight)
     pub fn create_devious_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::DeviousJoker,
                 "Devious Joker",
-                "+100 Chips if played hand contains a Straight",
+                "+100 Chips if played hand contains Straight",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -254,13 +254,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Crafty Joker (+80 Chips if played hand contains a Flush)
+    /// Create Crafty Joker (+80 Chips if played hand contains Flush)
     pub fn create_crafty_joker() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::CraftyJoker,
                 "Crafty Joker",
-                "+80 Chips if played hand contains a Flush",
+                "+80 Chips if played hand contains Flush",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -272,13 +272,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Even Steven (Even cards give +4 Mult when scored)
+    /// Create Even Steven (Even cards (2, 4, 6, 8, 10) give +4 Mult when scored)
     pub fn create_even_steven() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::EvenSteven,
                 "Even Steven",
-                "Played cards with even rank give +4 Mult when scored",
+                "Played cards with even rank (2, 4, 6, 8, 10) give +4 Mult when scored",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -296,13 +296,13 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Odd Todd (Odd cards give +31 Chips when scored)
+    /// Create Odd Todd (Odd cards (3, 5, 7, 9, A) give +31 Chips when scored)
     pub fn create_odd_todd() -> Box<dyn Joker> {
         Box::new(
             StaticJoker::builder(
                 JokerId::OddTodd,
                 "Odd Todd",
-                "Played cards with odd rank give +31 Chips when scored",
+                "Played cards with odd rank (3, 5, 7, 9, A) give +31 Chips when scored",
             )
             .rarity(JokerRarity::Common)
             .cost(4)
@@ -470,10 +470,7 @@ mod tests {
         let jolly = StaticJokerFactory::create_jolly_joker();
         assert_eq!(jolly.id(), JokerId::JollyJoker);
         assert_eq!(jolly.name(), "Jolly Joker");
-        assert_eq!(
-            jolly.description(),
-            "+8 Mult if played hand contains a Pair"
-        );
+        assert_eq!(jolly.description(), "+8 Mult if played hand contains Pair");
         assert_eq!(jolly.cost(), 3);
 
         // Test Zany Joker (Three of a Kind)
@@ -520,10 +517,7 @@ mod tests {
         let sly = StaticJokerFactory::create_sly_joker();
         assert_eq!(sly.id(), JokerId::SlyJoker);
         assert_eq!(sly.name(), "Sly Joker");
-        assert_eq!(
-            sly.description(),
-            "+50 Chips if played hand contains a Pair"
-        );
+        assert_eq!(sly.description(), "+50 Chips if played hand contains Pair");
 
         // Test Wily Joker (Three of a Kind)
         let wily = StaticJokerFactory::create_wily_joker();


### PR DESCRIPTION
Closes #138

## Summary
Fixed inconsistent string formatting in joker descriptions that was causing test failures. The issue was with hardcoded descriptions in the static joker factory not matching the expected format in tests.

## Changes Made

### Hand Type Description Formatting
- **Removed articles** ("a", "an") from hand type descriptions
- **Before**: "+12 Mult if played hand contains a Three of a Kind"  
- **After**: "+12 Mult if played hand contains Three of a Kind"
- **Applied to**: All hand type jokers (Pair, Two Pair, Three of a Kind, Straight, Flush, etc.)

### Rank Description Formatting  
- **Added rank examples** in parentheses to rank-based descriptions
- **Before**: "Played cards with even rank give +4 Mult when scored"
- **After**: "Played cards with even rank (2, 4, 6, 8, 10) give +4 Mult when scored"
- **Applied to**: Even Steven and Odd Todd jokers

### Documentation Updates
- Updated all documentation comments to match new description format
- Updated test expectations to align with corrected descriptions

## Test Results
✅ **All previously failing tests now pass:**
- `static_joker_factory::tests::test_all_hand_type_chip_jokers`
- `static_joker_factory::tests::test_all_hand_type_mult_jokers`  
- `static_joker_factory::tests::test_rank_based_jokers`

✅ **Pre-commit checks passed:**
- `cargo clippy --all -- -D warnings` ✅
- `cargo fmt` ✅  
- All issue-specific tests pass ✅

## Root Cause Analysis
The issue was with **hardcoded description strings** in `StaticJokerFactory` methods not matching the **expected format in test assertions**. This was a simple consistency issue between implementation and test expectations, not a logic error.

## Files Modified
- `core/src/static_joker_factory.rs` - Updated joker descriptions and comments

🤖 Generated with [Claude Code](https://claude.ai/code)