### PR TITLE
Add basic joker metadata access to Python bindings

### DIFF
--- a/core/src/joker_metadata.rs
+++ b/core/src/joker_metadata.rs
@@ -1,0 +1,283 @@
+use crate::joker::{JokerId, JokerRarity};
+use crate::joker_registry::{calculate_joker_cost, JokerDefinition, UnlockCondition};
+#[cfg(feature = "python")]
+use pyo3::pyclass;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Comprehensive metadata for a joker including all properties and state information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyclass)]
+pub struct JokerMetadata {
+    /// Core joker properties
+    pub id: JokerId,
+    pub name: String,
+    pub description: String,
+    pub rarity: JokerRarity,
+    pub cost: i32,
+    pub sell_value: i32,
+
+    /// Effect information
+    pub effect_type: String,
+    pub effect_description: String,
+    pub scaling_info: Option<HashMap<String, String>>,
+
+    /// Conditional information
+    pub triggers_on: Vec<String>,
+    pub conditions: Vec<String>,
+
+    /// State information
+    pub uses_state: bool,
+    pub max_triggers: Option<i32>,
+    pub persistent_data: bool,
+
+    /// Unlock information
+    pub unlock_condition: Option<UnlockCondition>,
+    pub is_unlocked: bool,
+}
+
+impl JokerMetadata {
+    /// Create a new JokerMetadata from a JokerDefinition
+    pub fn from_definition(definition: &JokerDefinition, is_unlocked: bool) -> Self {
+        // Extract cost based on rarity (using centralized function)
+        let cost = calculate_joker_cost(definition.rarity);
+
+        // Calculate sell value (half of cost)
+        let sell_value = cost / 2;
+
+        // Determine effect type based on description and ID
+        let effect_type = determine_effect_type(&definition.id, &definition.description);
+
+        // Extract trigger information
+        let triggers_on = extract_triggers(&definition.id, &definition.description);
+
+        // Extract condition information
+        let conditions = extract_conditions(&definition.id, &definition.description);
+
+        // Determine if joker uses state
+        let uses_state = check_uses_state(&definition.id);
+
+        // Extract max triggers if applicable
+        let max_triggers = extract_max_triggers(&definition.id);
+
+        // Check if joker uses persistent data
+        let persistent_data = check_persistent_data(&definition.id);
+
+        // Create effect description
+        let effect_description = create_effect_description(&definition.id, &definition.description);
+
+        Self {
+            id: definition.id,
+            name: definition.name.clone(),
+            description: definition.description.clone(),
+            rarity: definition.rarity,
+            cost,
+            sell_value,
+            effect_type,
+            effect_description,
+            scaling_info: None, // Will be populated in future PRs
+            triggers_on,
+            conditions,
+            uses_state,
+            max_triggers,
+            persistent_data,
+            unlock_condition: definition.unlock_condition.clone(),
+            is_unlocked,
+        }
+    }
+}
+
+/// Determine the effect type of a joker based on its ID and description
+fn determine_effect_type(id: &JokerId, description: &str) -> String {
+    // Basic pattern matching for effect types
+    if description.contains("Mult") {
+        if description.contains("×") || description.contains("X") {
+            "multiplicative_mult".to_string()
+        } else {
+            "additive_mult".to_string()
+        }
+    } else if description.contains("Chips") {
+        "additive_chips".to_string()
+    } else if description.contains("$") || description.contains("money") {
+        "economy".to_string()
+    } else if description.contains("hand size") {
+        "hand_modification".to_string()
+    } else if description.contains("discard") {
+        "discard_modification".to_string()
+    } else {
+        // Default based on specific joker IDs
+        match id {
+            JokerId::IceCream => "conditional_chips".to_string(),
+            _ => "special".to_string(),
+        }
+    }
+}
+
+/// Extract trigger conditions from joker description
+fn extract_triggers(id: &JokerId, description: &str) -> Vec<String> {
+    let mut triggers = Vec::new();
+
+    // Check for common trigger patterns
+    if description.contains("when scored") {
+        triggers.push("card_scored".to_string());
+    }
+    if description.contains("played") {
+        triggers.push("hand_played".to_string());
+    }
+    if description.contains("discarded") {
+        triggers.push("card_discarded".to_string());
+    }
+    if description.contains("round") {
+        triggers.push("round_end".to_string());
+    }
+    if description.contains("bought") || description.contains("purchased") {
+        triggers.push("item_purchased".to_string());
+    }
+
+    // Special cases for specific jokers
+    match id {
+        JokerId::IceCream => triggers.push("hand_played".to_string()),
+        JokerId::EggJoker => triggers.push("round_end".to_string()),
+        _ => {}
+    }
+
+    if triggers.is_empty() {
+        triggers.push("passive".to_string());
+    }
+
+    triggers
+}
+
+/// Extract condition information from joker
+fn extract_conditions(_id: &JokerId, description: &str) -> Vec<String> {
+    let mut conditions = Vec::new();
+
+    // Check for suit conditions
+    if description.contains("Heart") {
+        conditions.push("suit:hearts".to_string());
+    }
+    if description.contains("Diamond") {
+        conditions.push("suit:diamonds".to_string());
+    }
+    if description.contains("Club") {
+        conditions.push("suit:clubs".to_string());
+    }
+    if description.contains("Spade") {
+        conditions.push("suit:spades".to_string());
+    }
+
+    // Check for hand type conditions
+    let hand_types = ["Flush", "Straight", "Full House", "Four of a Kind", "Pair"];
+    for hand_type in &hand_types {
+        if description.contains(hand_type) {
+            conditions.push(format!("hand_type:{}", hand_type.to_lowercase().replace(' ', "_")));
+        }
+    }
+
+    // Check for other conditions
+    if description.contains("face card") {
+        conditions.push("face_card".to_string());
+    }
+    if description.contains("contains no") {
+        conditions.push("exclusion".to_string());
+    }
+
+    if conditions.is_empty() {
+        conditions.push("always".to_string());
+    }
+
+    conditions
+}
+
+/// Check if a joker uses state tracking
+fn check_uses_state(id: &JokerId) -> bool {
+    matches!(
+        id,
+        JokerId::IceCream
+            | JokerId::EggJoker
+            | JokerId::BurglarJoker
+            | JokerId::Cartomancer
+            | JokerId::SpaceJoker
+    )
+}
+
+/// Extract maximum trigger count for limited-use jokers
+fn extract_max_triggers(_id: &JokerId) -> Option<i32> {
+    // Most jokers have unlimited triggers
+    // Future jokers with limited uses would be added here
+    None
+}
+
+/// Check if a joker uses persistent data between rounds
+fn check_persistent_data(id: &JokerId) -> bool {
+    matches!(id, JokerId::IceCream | JokerId::EggJoker)
+}
+
+/// Create a detailed effect description
+fn create_effect_description(_id: &JokerId, base_description: &str) -> String {
+    // For now, use the base description
+    // In future PRs, this will be enhanced with more detailed effect information
+    base_description.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_joker_metadata_creation() {
+        let definition = JokerDefinition {
+            id: JokerId::Joker,
+            name: "Joker".to_string(),
+            description: "+4 Mult".to_string(),
+            rarity: JokerRarity::Common,
+            unlock_condition: None,
+        };
+
+        let metadata = JokerMetadata::from_definition(&definition, true);
+
+        assert_eq!(metadata.id, JokerId::Joker);
+        assert_eq!(metadata.name, "Joker");
+        assert_eq!(metadata.cost, 3); // Common rarity
+        assert_eq!(metadata.sell_value, 1); // Half of cost
+        assert_eq!(metadata.effect_type, "additive_mult");
+        assert!(metadata.is_unlocked);
+        assert!(!metadata.uses_state);
+    }
+
+    #[test]
+    fn test_effect_type_detection() {
+        assert_eq!(
+            determine_effect_type(&JokerId::Joker, "+4 Mult"),
+            "additive_mult"
+        );
+        assert_eq!(
+            determine_effect_type(&JokerId::Joker, "X2 Mult"),
+            "multiplicative_mult"
+        );
+        assert_eq!(
+            determine_effect_type(&JokerId::Joker, "+100 Chips"),
+            "additive_chips"
+        );
+        assert_eq!(
+            determine_effect_type(&JokerId::Joker, "Earn $3"),
+            "economy"
+        );
+    }
+
+    #[test]
+    fn test_trigger_extraction() {
+        let triggers = extract_triggers(&JokerId::GreedyJoker, "Played cards with Diamond suit give +3 Mult when scored");
+        assert!(triggers.contains(&"card_scored".to_string()));
+        
+        // Test a different joker that triggers on hand played
+        let triggers2 = extract_triggers(&JokerId::IceCream, "Ice Cream gives chips");
+        assert!(triggers2.contains(&"hand_played".to_string()));
+    }
+
+    #[test]
+    fn test_condition_extraction() {
+        let conditions = extract_conditions(&JokerId::GreedyJoker, "Played cards with Diamond suit give +3 Mult when scored");
+        assert!(conditions.contains(&"suit:diamonds".to_string()));
+    }
+}

--- a/core/src/joker_metadata.rs
+++ b/core/src/joker_metadata.rs
@@ -170,7 +170,10 @@ fn extract_conditions(_id: &JokerId, description: &str) -> Vec<String> {
     let hand_types = ["Flush", "Straight", "Full House", "Four of a Kind", "Pair"];
     for hand_type in &hand_types {
         if description.contains(hand_type) {
-            conditions.push(format!("hand_type:{}", hand_type.to_lowercase().replace(' ', "_")));
+            conditions.push(format!(
+                "hand_type:{}",
+                hand_type.to_lowercase().replace(' ', "_")
+            ));
         }
     }
 
@@ -259,17 +262,17 @@ mod tests {
             determine_effect_type(&JokerId::Joker, "+100 Chips"),
             "additive_chips"
         );
-        assert_eq!(
-            determine_effect_type(&JokerId::Joker, "Earn $3"),
-            "economy"
-        );
+        assert_eq!(determine_effect_type(&JokerId::Joker, "Earn $3"), "economy");
     }
 
     #[test]
     fn test_trigger_extraction() {
-        let triggers = extract_triggers(&JokerId::GreedyJoker, "Played cards with Diamond suit give +3 Mult when scored");
+        let triggers = extract_triggers(
+            &JokerId::GreedyJoker,
+            "Played cards with Diamond suit give +3 Mult when scored",
+        );
         assert!(triggers.contains(&"card_scored".to_string()));
-        
+
         // Test a different joker that triggers on hand played
         let triggers2 = extract_triggers(&JokerId::IceCream, "Ice Cream gives chips");
         assert!(triggers2.contains(&"hand_played".to_string()));
@@ -277,7 +280,10 @@ mod tests {
 
     #[test]
     fn test_condition_extraction() {
-        let conditions = extract_conditions(&JokerId::GreedyJoker, "Played cards with Diamond suit give +3 Mult when scored");
+        let conditions = extract_conditions(
+            &JokerId::GreedyJoker,
+            "Played cards with Diamond suit give +3 Mult when scored",
+        );
         assert!(conditions.contains(&"suit:diamonds".to_string()));
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod joker;
 pub mod joker_effect_processor;
 pub mod joker_factory;
 pub mod joker_impl;
+pub mod joker_metadata;
 pub mod joker_registry;
 pub mod joker_state;
 pub mod rank;

--- a/pylatro/src/lib.rs
+++ b/pylatro/src/lib.rs
@@ -5,6 +5,7 @@ use balatro_rs::config::Config;
 use balatro_rs::error::GameError;
 use balatro_rs::game::Game;
 use balatro_rs::joker::{JokerId, JokerRarity, Jokers};
+use balatro_rs::joker_metadata::JokerMetadata;
 use balatro_rs::joker_registry::{registry, JokerDefinition, UnlockCondition};
 use balatro_rs::stage::{End, Stage};
 use pyo3::prelude::*;
@@ -168,6 +169,82 @@ impl GameEngine {
             }
         }
         false
+    }
+
+    // Basic Metadata Access Methods
+
+    /// Get comprehensive metadata for a specific joker
+    fn get_joker_metadata(&self, joker_id: JokerId) -> PyResult<Option<JokerMetadata>> {
+        match registry::get_definition(&joker_id) {
+            Ok(Some(definition)) => {
+                // Check if joker is unlocked (simplified for now)
+                let is_unlocked = true; // TODO: Implement actual unlock checking
+                let metadata = JokerMetadata::from_definition(&definition, is_unlocked);
+                Ok(Some(metadata))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                format!("Failed to get joker metadata: {}", e)
+            )),
+        }
+    }
+
+    /// Get basic properties of a joker as a dictionary
+    fn get_joker_properties(&self, joker_id: JokerId) -> PyResult<Option<pyo3::types::PyDict>> {
+        Python::with_gil(|py| {
+            match self.get_joker_metadata(joker_id)? {
+                Some(metadata) => {
+                    let dict = pyo3::types::PyDict::new(py);
+                    dict.set_item("id", format!("{:?}", metadata.id))?;
+                    dict.set_item("name", metadata.name)?;
+                    dict.set_item("description", metadata.description)?;
+                    dict.set_item("rarity", format!("{:?}", metadata.rarity))?;
+                    dict.set_item("cost", metadata.cost)?;
+                    dict.set_item("sell_value", metadata.sell_value)?;
+                    Ok(Some(dict.into()))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+
+    /// Get effect information for a joker
+    fn get_joker_effect_info(&self, joker_id: JokerId) -> PyResult<Option<pyo3::types::PyDict>> {
+        Python::with_gil(|py| {
+            match self.get_joker_metadata(joker_id)? {
+                Some(metadata) => {
+                    let dict = pyo3::types::PyDict::new(py);
+                    dict.set_item("effect_type", metadata.effect_type)?;
+                    dict.set_item("effect_description", metadata.effect_description)?;
+                    dict.set_item("triggers_on", metadata.triggers_on)?;
+                    dict.set_item("conditions", metadata.conditions)?;
+                    dict.set_item("uses_state", metadata.uses_state)?;
+                    dict.set_item("max_triggers", metadata.max_triggers)?;
+                    dict.set_item("persistent_data", metadata.persistent_data)?;
+                    Ok(Some(dict.into()))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+
+    /// Get unlock status and condition for a joker
+    fn get_joker_unlock_status(&self, joker_id: JokerId) -> PyResult<Option<pyo3::types::PyDict>> {
+        Python::with_gil(|py| {
+            match self.get_joker_metadata(joker_id)? {
+                Some(metadata) => {
+                    let dict = pyo3::types::PyDict::new(py);
+                    dict.set_item("is_unlocked", metadata.is_unlocked)?;
+                    if let Some(condition) = metadata.unlock_condition {
+                        dict.set_item("unlock_condition", format!("{:?}", condition))?;
+                    } else {
+                        dict.set_item("unlock_condition", py.None())?;
+                    }
+                    Ok(Some(dict.into()))
+                }
+                None => Ok(None),
+            }
+        })
     }
 }
 
@@ -448,6 +525,7 @@ fn pylatro(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<JokerRarity>()?;
     m.add_class::<JokerDefinition>()?;
     m.add_class::<UnlockCondition>()?;
+    m.add_class::<JokerMetadata>()?;
 
     Ok(())
 }

--- a/pylatro/src/lib.rs
+++ b/pylatro/src/lib.rs
@@ -9,7 +9,7 @@ use balatro_rs::joker_metadata::JokerMetadata;
 use balatro_rs::joker_registry::{registry, JokerDefinition, UnlockCondition};
 use balatro_rs::stage::{End, Stage};
 use pyo3::prelude::*;
-use pyo3::{PyResult, Python};
+use pyo3::{PyObject, PyResult, Python};
 
 /// A serializable snapshot of the game state for Python bindings
 #[derive(Clone)]
@@ -183,67 +183,61 @@ impl GameEngine {
                 Ok(Some(metadata))
             }
             Ok(None) => Ok(None),
-            Err(e) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                format!("Failed to get joker metadata: {}", e)
-            )),
+            Err(e) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Failed to get joker metadata: {e}"
+            ))),
         }
     }
 
     /// Get basic properties of a joker as a dictionary
-    fn get_joker_properties(&self, joker_id: JokerId) -> PyResult<Option<pyo3::types::PyDict>> {
-        Python::with_gil(|py| {
-            match self.get_joker_metadata(joker_id)? {
-                Some(metadata) => {
-                    let dict = pyo3::types::PyDict::new(py);
-                    dict.set_item("id", format!("{:?}", metadata.id))?;
-                    dict.set_item("name", metadata.name)?;
-                    dict.set_item("description", metadata.description)?;
-                    dict.set_item("rarity", format!("{:?}", metadata.rarity))?;
-                    dict.set_item("cost", metadata.cost)?;
-                    dict.set_item("sell_value", metadata.sell_value)?;
-                    Ok(Some(dict.into()))
-                }
-                None => Ok(None),
+    fn get_joker_properties(&self, joker_id: JokerId) -> PyResult<Option<PyObject>> {
+        Python::with_gil(|py| match self.get_joker_metadata(joker_id)? {
+            Some(metadata) => {
+                let dict = pyo3::types::PyDict::new(py);
+                dict.set_item("id", format!("{:?}", metadata.id))?;
+                dict.set_item("name", metadata.name)?;
+                dict.set_item("description", metadata.description)?;
+                dict.set_item("rarity", format!("{:?}", metadata.rarity))?;
+                dict.set_item("cost", metadata.cost)?;
+                dict.set_item("sell_value", metadata.sell_value)?;
+                Ok(Some(dict.into()))
             }
+            None => Ok(None),
         })
     }
 
     /// Get effect information for a joker
-    fn get_joker_effect_info(&self, joker_id: JokerId) -> PyResult<Option<pyo3::types::PyDict>> {
-        Python::with_gil(|py| {
-            match self.get_joker_metadata(joker_id)? {
-                Some(metadata) => {
-                    let dict = pyo3::types::PyDict::new(py);
-                    dict.set_item("effect_type", metadata.effect_type)?;
-                    dict.set_item("effect_description", metadata.effect_description)?;
-                    dict.set_item("triggers_on", metadata.triggers_on)?;
-                    dict.set_item("conditions", metadata.conditions)?;
-                    dict.set_item("uses_state", metadata.uses_state)?;
-                    dict.set_item("max_triggers", metadata.max_triggers)?;
-                    dict.set_item("persistent_data", metadata.persistent_data)?;
-                    Ok(Some(dict.into()))
-                }
-                None => Ok(None),
+    fn get_joker_effect_info(&self, joker_id: JokerId) -> PyResult<Option<PyObject>> {
+        Python::with_gil(|py| match self.get_joker_metadata(joker_id)? {
+            Some(metadata) => {
+                let dict = pyo3::types::PyDict::new(py);
+                dict.set_item("effect_type", metadata.effect_type)?;
+                dict.set_item("effect_description", metadata.effect_description)?;
+                dict.set_item("triggers_on", metadata.triggers_on)?;
+                dict.set_item("conditions", metadata.conditions)?;
+                dict.set_item("uses_state", metadata.uses_state)?;
+                dict.set_item("max_triggers", metadata.max_triggers)?;
+                dict.set_item("persistent_data", metadata.persistent_data)?;
+                Ok(Some(dict.into()))
             }
+            None => Ok(None),
         })
     }
 
     /// Get unlock status and condition for a joker
-    fn get_joker_unlock_status(&self, joker_id: JokerId) -> PyResult<Option<pyo3::types::PyDict>> {
-        Python::with_gil(|py| {
-            match self.get_joker_metadata(joker_id)? {
-                Some(metadata) => {
-                    let dict = pyo3::types::PyDict::new(py);
-                    dict.set_item("is_unlocked", metadata.is_unlocked)?;
-                    if let Some(condition) = metadata.unlock_condition {
-                        dict.set_item("unlock_condition", format!("{:?}", condition))?;
-                    } else {
-                        dict.set_item("unlock_condition", py.None())?;
-                    }
-                    Ok(Some(dict.into()))
+    fn get_joker_unlock_status(&self, joker_id: JokerId) -> PyResult<Option<PyObject>> {
+        Python::with_gil(|py| match self.get_joker_metadata(joker_id)? {
+            Some(metadata) => {
+                let dict = pyo3::types::PyDict::new(py);
+                dict.set_item("is_unlocked", metadata.is_unlocked)?;
+                if let Some(condition) = metadata.unlock_condition {
+                    dict.set_item("unlock_condition", format!("{condition:?}"))?;
+                } else {
+                    dict.set_item("unlock_condition", py.None())?;
                 }
-                None => Ok(None),
+                Ok(Some(dict.into()))
             }
+            None => Ok(None),
         })
     }
 }

--- a/pylatro/test/test_joker_metadata.py
+++ b/pylatro/test/test_joker_metadata.py
@@ -1,0 +1,135 @@
+import pytest
+import sys
+import os
+
+# Add the parent directory to the path so we can import pylatro
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pylatro
+
+
+def test_get_joker_metadata():
+    """Test getting comprehensive joker metadata"""
+    engine = pylatro.GameEngine()
+    
+    # Test getting metadata for existing joker
+    metadata = engine.get_joker_metadata(pylatro.JokerId.Joker)
+    assert metadata is not None
+    assert metadata.id == pylatro.JokerId.Joker
+    assert metadata.name == "Joker"
+    assert metadata.description == "+4 Mult"
+    assert metadata.rarity == pylatro.JokerRarity.Common
+    assert metadata.cost == 3  # Common joker cost
+    assert metadata.sell_value == 1  # Half of cost
+    assert metadata.effect_type == "additive_mult"
+    assert metadata.is_unlocked == True  # Currently always true
+    
+    # Test getting metadata for non-existent joker
+    metadata = engine.get_joker_metadata(pylatro.JokerId.PlaceholderJoker)
+    assert metadata is None
+
+
+def test_get_joker_properties():
+    """Test getting basic joker properties as dictionary"""
+    engine = pylatro.GameEngine()
+    
+    # Test getting properties for existing joker
+    props = engine.get_joker_properties(pylatro.JokerId.Joker)
+    assert props is not None
+    assert isinstance(props, dict)
+    assert props["name"] == "Joker"
+    assert props["description"] == "+4 Mult"
+    assert props["cost"] == 3
+    assert props["sell_value"] == 1
+    assert "rarity" in props
+    assert "id" in props
+    
+    # Test getting properties for non-existent joker
+    props = engine.get_joker_properties(pylatro.JokerId.PlaceholderJoker)
+    assert props is None
+
+
+def test_get_joker_effect_info():
+    """Test getting joker effect information"""
+    engine = pylatro.GameEngine()
+    
+    # Test basic mult joker
+    effect_info = engine.get_joker_effect_info(pylatro.JokerId.Joker)
+    assert effect_info is not None
+    assert effect_info["effect_type"] == "additive_mult"
+    assert effect_info["effect_description"] == "+4 Mult"
+    assert isinstance(effect_info["triggers_on"], list)
+    assert "passive" in effect_info["triggers_on"]
+    assert isinstance(effect_info["conditions"], list)
+    assert "always" in effect_info["conditions"]
+    assert effect_info["uses_state"] == False
+    assert effect_info["max_triggers"] is None
+    assert effect_info["persistent_data"] == False
+    
+    # Test suit-based joker
+    effect_info = engine.get_joker_effect_info(pylatro.JokerId.GreedyJoker)
+    assert effect_info is not None
+    assert "card_scored" in effect_info["triggers_on"]
+    assert "suit:diamonds" in effect_info["conditions"]
+    
+    # Test non-existent joker
+    effect_info = engine.get_joker_effect_info(pylatro.JokerId.PlaceholderJoker)
+    assert effect_info is None
+
+
+def test_get_joker_unlock_status():
+    """Test getting joker unlock status and conditions"""
+    engine = pylatro.GameEngine()
+    
+    # Test basic joker (no unlock condition)
+    unlock_info = engine.get_joker_unlock_status(pylatro.JokerId.Joker)
+    assert unlock_info is not None
+    assert unlock_info["is_unlocked"] == True
+    assert unlock_info["unlock_condition"] is None
+    
+    # Test joker with unlock condition
+    # Note: Need to find a joker with actual unlock condition
+    # For now, all jokers return is_unlocked=True
+    
+    # Test non-existent joker
+    unlock_info = engine.get_joker_unlock_status(pylatro.JokerId.PlaceholderJoker)
+    assert unlock_info is None
+
+
+def test_metadata_for_different_rarities():
+    """Test metadata for jokers of different rarities"""
+    engine = pylatro.GameEngine()
+    
+    # Common joker
+    metadata = engine.get_joker_metadata(pylatro.JokerId.Joker)
+    assert metadata.rarity == pylatro.JokerRarity.Common
+    assert metadata.cost == 3
+    
+    # TODO: Add tests for Uncommon, Rare, and Legendary jokers
+    # when they are available in the registry
+
+
+def test_effect_type_detection():
+    """Test that effect types are correctly detected"""
+    engine = pylatro.GameEngine()
+    
+    # Additive mult
+    metadata = engine.get_joker_metadata(pylatro.JokerId.Joker)
+    assert metadata.effect_type == "additive_mult"
+    
+    # Conditional chips (Ice Cream)
+    metadata = engine.get_joker_metadata(pylatro.JokerId.IceCream)
+    if metadata:  # Ice Cream might not be registered yet
+        assert metadata.effect_type == "conditional_chips"
+        assert metadata.uses_state == True
+        assert metadata.persistent_data == True
+
+
+if __name__ == "__main__":
+    test_get_joker_metadata()
+    test_get_joker_properties()
+    test_get_joker_effect_info()
+    test_get_joker_unlock_status()
+    test_metadata_for_different_rarities()
+    test_effect_type_detection()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

This PR adds basic single-joker metadata access methods to the Python bindings. These are the core methods that allow Python users to retrieve joker information.

### Changes Made

1. **New Python methods in GameEngine**:
   - `get_joker_metadata(joker_id)`: Returns full JokerMetadata object
   - `get_joker_properties(joker_id)`: Returns basic properties as dictionary
   - `get_joker_effect_info(joker_id)`: Returns effect information as dictionary
   - `get_joker_unlock_status(joker_id)`: Returns unlock status and condition as dictionary

2. **Module updates**:
   - Added JokerMetadata import
   - Exposed JokerMetadata class to Python

3. **Test suite**:
   - Comprehensive tests for all four methods
   - Tests for different joker types and edge cases
   - Tests for non-existent jokers return None

### Dependencies

⚠️ **This PR depends on PR #251** (Core Metadata Infrastructure) which has been merged.

### Design Decisions

- Methods return dictionaries for easy Python consumption
- Non-existent jokers return None instead of raising exceptions
- All methods are synchronous and lightweight
- Unlock status currently always returns true (TODO for future PR)

### Testing

- ✅ Rust code compiles without warnings
- ✅ Python test suite created with comprehensive coverage
- ✅ No breaking changes

### Part of PR Split

This is part of splitting PR #221 into smaller, focused PRs as tracked in issue #249. This PR provides basic access methods only.

### Next Steps

Once this is merged, the following PRs can be created:
- PR 4: Batch Operations (get_multiple_joker_metadata, etc.)
- PR 5: Search and Filtering
- PR 6: State and Effects
- PR 7: Advanced Features

🤖 Generated with [Claude Code](https://claude.ai/code)