### PR TITLE
🚨 HOTFIX: Remove merge conflict markers from pylatro/src/lib.rs

### DIFF
--- a/core/src/game.rs
+++ b/core/src/game.rs
@@ -370,7 +370,7 @@ impl Game {
 
         // compute score
         let score = self.chips * self.mult;
-        
+
         // Check for killscreen condition
         if !score.is_finite() {
             self.add_debug_message("KILLSCREEN: Final score reached infinity!".to_string());
@@ -428,10 +428,11 @@ impl Game {
                 // Handle mult_multiplier: 0.0 means no multiplier, so treat as 1.0
                 if effect.mult_multiplier != 0.0 {
                     total_mult_multiplier *= effect.mult_multiplier;
-                    
+
                     // Killscreen detection - stop processing if we hit NaN/Infinity
                     if !total_mult_multiplier.is_finite() {
-                        messages.push("KILLSCREEN: Score calculation reached infinity!".to_string());
+                        messages
+                            .push("KILLSCREEN: Score calculation reached infinity!".to_string());
                         break;
                     }
                 }
@@ -483,10 +484,12 @@ impl Game {
                         // Handle mult_multiplier: 0.0 means no multiplier, so treat as 1.0
                         if effect.mult_multiplier != 0.0 {
                             total_mult_multiplier *= effect.mult_multiplier;
-                            
+
                             // Killscreen detection - stop processing if we hit NaN/Infinity
                             if !total_mult_multiplier.is_finite() {
-                                messages.push("KILLSCREEN: Score calculation reached infinity!".to_string());
+                                messages.push(
+                                    "KILLSCREEN: Score calculation reached infinity!".to_string(),
+                                );
                                 break;
                             }
                         }
@@ -652,15 +655,16 @@ impl Game {
     pub fn get_debug_messages(&self) -> &[String] {
         &self.debug_messages
     }
-    
+
     /// Add a debug message with automatic memory management
     fn add_debug_message(&mut self, message: String) {
         if self.debug_logging_enabled {
             self.debug_messages.push(message);
-            
+
             // Keep memory usage reasonable - remove oldest messages if we exceed limit
             if self.debug_messages.len() > MAX_DEBUG_MESSAGES {
-                self.debug_messages.drain(0..self.debug_messages.len() - MAX_DEBUG_MESSAGES);
+                self.debug_messages
+                    .drain(0..self.debug_messages.len() - MAX_DEBUG_MESSAGES);
             }
         }
     }

--- a/core/tests/joker_scoring_integration_test.rs
+++ b/core/tests/joker_scoring_integration_test.rs
@@ -183,7 +183,7 @@ fn test_killscreen_behavior() {
     // 1e200 * 1e200 = 1e400 which exceeds f64 max (~1.8e308) and becomes infinity
     let extreme_joker = Box::new(TestOrderJoker::new(1, 0, 0, 1e200));
     game.jokers.push(extreme_joker);
-    
+
     // Add a second joker with the same extreme multiplier to ensure overflow
     let extreme_joker2 = Box::new(TestOrderJoker::new(2, 0, 0, 1e200));
     game.jokers.push(extreme_joker2);
@@ -202,7 +202,7 @@ fn test_killscreen_behavior() {
 
     // Score should be infinite (killscreen reached) OR we should have killscreen message
     let has_killscreen_msg = debug_messages.iter().any(|msg| msg.contains("KILLSCREEN"));
-    
+
     // Test passes if either score is infinite OR we got a killscreen message
     assert!(
         !score.is_finite() || has_killscreen_msg,

--- a/pylatro/src/lib.rs
+++ b/pylatro/src/lib.rs
@@ -13,7 +13,7 @@ use balatro_rs::joker_registry::{
 };
 use balatro_rs::stage::{End, Stage};
 use pyo3::prelude::*;
-use pyo3::{PyObject, PyResult, Python};
+use pyo3::{PyResult, Python};
 use std::collections::HashMap;
 
 // Security constants for input validation
@@ -136,7 +136,7 @@ impl GameEngine {
         // Check if player can afford it
         if let Ok(Some(definition)) = registry::get_definition(&joker_id) {
             let cost = calculate_joker_cost(definition.rarity) as usize;
-            return self.game.money >= cost;
+            return self.game.money >= cost as f64;
         }
 
         false
@@ -535,7 +535,7 @@ impl GameEngine {
                     // Filter by affordability if requested
                     if affordable_only {
                         let cost = calculate_joker_cost(def.rarity);
-                        if self.game.money < cost as usize {
+                        if self.game.money < cost as f64 {
                             return false;
                         }
                     }
@@ -813,7 +813,6 @@ impl GameEngine {
         false
     }
 
-<<<<<<< HEAD
     /// Get all active joker states
     fn get_joker_states(&self) -> pyo3::PyObject {
         pyo3::Python::with_gil(|py| {
@@ -1198,8 +1197,8 @@ fn evaluate_unlock_condition(condition: &UnlockCondition, game: &Game) -> bool {
             };
             current_ante_num >= *required_ante
         }
-        UnlockCondition::HaveMoney(required_money) => game.money >= *required_money as usize,
-        UnlockCondition::ScoreInHand(required_score) => game.score >= *required_score as usize,
+        UnlockCondition::HaveMoney(required_money) => game.money >= *required_money as f64,
+        UnlockCondition::ScoreInHand(required_score) => game.score >= *required_score as f64,
         UnlockCondition::PlayHands(required_hands) => {
             // Sum all hand type counts to get total hands played
             let total_hands: u32 = game.hand_type_counts.values().sum();


### PR DESCRIPTION
## Summary
- Removes orphaned `<<<<<<< HEAD` merge conflict marker at line 816 in `pylatro/src/lib.rs` that was blocking all CI workflows
- Fixes type casting errors between f64 and usize/i32 types for money/score comparisons
- Removes unused `PyObject` import to eliminate compiler warning
- Applies cargo fmt formatting fixes

## Test plan
- [x] Code compiles successfully with `cargo build`
- [x] All merge conflict markers removed
- [x] Type casting errors resolved
- [x] Cargo fmt passes without issues

This is a critical P0 hotfix that resolves Issue #266 and unblocks all development workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)