### PR TITLE
🚨 HOTFIX: Fix rustfmt formatting violations in core/src/game.rs

### DIFF
--- a/core/src/game.rs
+++ b/core/src/game.rs
@@ -370,7 +370,7 @@ impl Game {
 
         // compute score
         let score = self.chips * self.mult;
-        
+
         // Check for killscreen condition
         if !score.is_finite() {
             self.add_debug_message("KILLSCREEN: Final score reached infinity!".to_string());
@@ -428,10 +428,11 @@ impl Game {
                 // Handle mult_multiplier: 0.0 means no multiplier, so treat as 1.0
                 if effect.mult_multiplier != 0.0 {
                     total_mult_multiplier *= effect.mult_multiplier;
-                    
+
                     // Killscreen detection - stop processing if we hit NaN/Infinity
                     if !total_mult_multiplier.is_finite() {
-                        messages.push("KILLSCREEN: Score calculation reached infinity!".to_string());
+                        messages
+                            .push("KILLSCREEN: Score calculation reached infinity!".to_string());
                         break;
                     }
                 }
@@ -483,10 +484,12 @@ impl Game {
                         // Handle mult_multiplier: 0.0 means no multiplier, so treat as 1.0
                         if effect.mult_multiplier != 0.0 {
                             total_mult_multiplier *= effect.mult_multiplier;
-                            
+
                             // Killscreen detection - stop processing if we hit NaN/Infinity
                             if !total_mult_multiplier.is_finite() {
-                                messages.push("KILLSCREEN: Score calculation reached infinity!".to_string());
+                                messages.push(
+                                    "KILLSCREEN: Score calculation reached infinity!".to_string(),
+                                );
                                 break;
                             }
                         }
@@ -652,15 +655,16 @@ impl Game {
     pub fn get_debug_messages(&self) -> &[String] {
         &self.debug_messages
     }
-    
+
     /// Add a debug message with automatic memory management
     fn add_debug_message(&mut self, message: String) {
         if self.debug_logging_enabled {
             self.debug_messages.push(message);
-            
+
             // Keep memory usage reasonable - remove oldest messages if we exceed limit
             if self.debug_messages.len() > MAX_DEBUG_MESSAGES {
-                self.debug_messages.drain(0..self.debug_messages.len() - MAX_DEBUG_MESSAGES);
+                self.debug_messages
+                    .drain(0..self.debug_messages.len() - MAX_DEBUG_MESSAGES);
             }
         }
     }

--- a/core/tests/joker_scoring_integration_test.rs
+++ b/core/tests/joker_scoring_integration_test.rs
@@ -183,7 +183,7 @@ fn test_killscreen_behavior() {
     // 1e200 * 1e200 = 1e400 which exceeds f64 max (~1.8e308) and becomes infinity
     let extreme_joker = Box::new(TestOrderJoker::new(1, 0, 0, 1e200));
     game.jokers.push(extreme_joker);
-    
+
     // Add a second joker with the same extreme multiplier to ensure overflow
     let extreme_joker2 = Box::new(TestOrderJoker::new(2, 0, 0, 1e200));
     game.jokers.push(extreme_joker2);
@@ -202,7 +202,7 @@ fn test_killscreen_behavior() {
 
     // Score should be infinite (killscreen reached) OR we should have killscreen message
     let has_killscreen_msg = debug_messages.iter().any(|msg| msg.contains("KILLSCREEN"));
-    
+
     // Test passes if either score is infinite OR we got a killscreen message
     assert!(
         !score.is_finite() || has_killscreen_msg,

--- a/pylatro/src/lib.rs
+++ b/pylatro/src/lib.rs
@@ -813,7 +813,6 @@ impl GameEngine {
         false
     }
 
-<<<<<<< HEAD
     /// Get all active joker states
     fn get_joker_states(&self) -> pyo3::PyObject {
         pyo3::Python::with_gil(|py| {


### PR DESCRIPTION
## Summary

Emergency fix for rustfmt formatting violations that were blocking CI pipeline formatting checks.

- Fixed trailing whitespace on lines 370, 428, 483, 652, 659 in `core/src/game.rs`
- Fixed line wrapping for long statements (messages.push calls) to comply with rustfmt line length limits
- Resolved merge conflict marker in `pylatro/src/lib.rs` line 816
- Applied `cargo fmt --all` to ensure consistent formatting throughout codebase
- All rustfmt checks now pass cleanly (`cargo fmt --all -- --check` succeeds)

## Test plan

- [x] Run `cargo fmt --all -- --check` to verify all formatting issues resolved
- [x] Verify compilation succeeds (formatting changes only, no logic changes)
- [x] Confirm no trailing whitespace or line length violations remain

**Closes #267**

🤖 Generated with [Claude Code](https://claude.ai/code)