### PR TITLE
🚨 EMERGENCY HOTFIX: [P1] Fix Windows test summary script shell compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
             ${{ matrix.os }}-cargo-build-target-
       
       - name: Run tests
+        shell: bash
         run: |
           # Run all tests with verbose output and capture results
           set +e  # Don't exit on test failure, we want to capture the results
@@ -77,6 +78,7 @@ jobs:
           
       - name: Generate test summary
         if: always()
+        shell: bash
         run: |
           echo "## Test Results Summary" > test_summary.md
           echo "- OS: ${{ matrix.os }}" >> test_summary.md


### PR DESCRIPTION
## Emergency Fix for Windows CI Issue

### Impact
- **Severity**: P1
- **Affected Systems**: Windows CI runners 
- **User Impact**: CI failing on Windows builds, blocking development workflow

### Root Cause
Windows CI runners use PowerShell by default, but CI test scripts use bash syntax:
- `TEST_EXIT_CODE=$?` is bash-specific, not PowerShell compatible
- `if [ -f test_output.log ]; then` uses bash conditional syntax
- PowerShell parser fails with "Missing '(' after 'if' in if statement" errors

### Solution
Added `shell: bash` directive to problematic CI workflow steps:
- **Run tests** step in cross-platform test matrix  
- **Generate test summary** step in cross-platform test matrix

This forces Windows runners to use bash instead of PowerShell for script execution.

### Testing
- [x] Syntax validated against GitHub Actions schema
- [x] Change isolated to Windows CI compatibility issue
- [x] Ubuntu/macOS CI unaffected (already use bash by default)
- [x] Emergency work tree isolation maintained

### Deployment
- **Target Environment**: Main branch
- **Deployment Window**: IMMEDIATE  
- **Rollback Strategy**: Simple revert of CI workflow changes

### Related Issues
Follows emergency PR #274 which fixed rustfmt/clippy issues.

🤖 Generated with [Claude Code](https://claude.ai/code)