### PR TITLE
Fix documentation deployment by adding git dependency to containers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,8 +272,8 @@ jobs:
         run: cargo doc --all --no-deps
       
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
-          cname: balatro-rs-docs.example.com  # Update with actual domain if needed
+          # cname: balatro-rs-docs.example.com  # Update with actual domain if needed

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y pkg-config libssl-dev python3 python3-dev
+          apt-get install -y pkg-config libssl-dev python3 python3-dev git
       
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -109,7 +109,7 @@ jobs:
       
       - name: Deploy documentation (main branch only)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
@@ -127,7 +127,7 @@ jobs:
       - name: Install Python and dependencies
         run: |
           apt-get update
-          apt-get install -y python3 python3-dev python3-venv python3-pip pkg-config libssl-dev
+          apt-get install -y python3 python3-dev python3-venv python3-pip pkg-config libssl-dev git
           
       - name: Setup Python virtual environment
         run: |

--- a/core/src/bounded_action_history.rs
+++ b/core/src/bounded_action_history.rs
@@ -9,7 +9,7 @@ pub const DEFAULT_MAX_ACTIONS: usize = 10_000;
 
 /// Bounded circular buffer for action history to prevent memory leaks
 ///
-/// This replaces the unbounded Vec<Action> with a memory-efficient circular buffer
+/// This replaces the unbounded `Vec<Action>` with a memory-efficient circular buffer
 /// that maintains only the most recent actions up to a configurable limit.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Fix GitHub Actions documentation deployment failure caused by missing git in Docker containers
- Update peaceiris/actions-gh-pages action to v4 for better container support  
- Fix rustdoc HTML tag warning in bounded_action_history.rs

## Problem
The `peaceiris/actions-gh-pages@v3` action was failing with error: "Unable to locate executable file: git" because the `rust:slim` container doesn't include git by default.

## Solution
- Add `git` package to apt-get install commands in both docs.yml container jobs
- Update to `peaceiris/actions-gh-pages@v4` which handles container environments better
- Fix unrelated rustdoc warning by wrapping `Vec<Action>` in backticks
- Clean up example CNAME domain setting in deploy.yml

## Test plan
- [x] Documentation generation works locally without warnings
- [ ] GitHub Actions workflow runs successfully
- [ ] Documentation deploys to gh-pages branch correctly

🤖 Generated with [Claude Code](https://claude.ai/code)