### PR TITLE
Fix #337: Add backup files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ __pycache__/
 *.pyo
 *.pyd
 # Trigger CI re-run to validate current formatting fixes
+
+# Backup files
+*.backup
+*.bak
+*.old
+*.orig


### PR DESCRIPTION
## Summary
- Add patterns to .gitignore to prevent backup files from being committed
- Includes *.backup, *.bak, *.old, *.orig patterns
- Tested that all patterns work correctly

## Changes
- Added backup file patterns to .gitignore with clear section header
- Followed .gitignore best practices for pattern placement
- Verified patterns work by testing with sample files

## Testing
- Created test backup files (*.backup, *.bak, *.old, *.orig)
- Verified files are properly ignored by git status
- Cleaned up test files after verification

Resolves #337