### PR TITLE
Fix #335: Move security tests to proper tests directory

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -23,7 +23,6 @@ pub mod math_safe;
 pub mod memory_monitor;
 pub mod rank;
 pub mod rng;
-pub mod security_tests;
 pub mod shop;
 pub mod space;
 pub mod stage;

--- a/core/tests/security_tests.rs
+++ b/core/tests/security_tests.rs
@@ -5,12 +5,12 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::config::Config;
-    use crate::math_safe::{
+    use balatro_rs::config::Config;
+    use balatro_rs::math_safe::{
         safe_add, safe_divide, safe_multiply, safe_size_for_move_operations, safe_subtract,
         saturating_subtract, validate_array_size, MathError,
     };
-    use crate::space::ActionSpace;
+    use balatro_rs::space::ActionSpace;
 
     /// Test that ActionSpace creation handles zero available_max without underflow
     #[test]


### PR DESCRIPTION
## Summary
- Updated imports in `security_tests.rs` from `crate::` to `balatro_rs::`
- Moved `core/src/security_tests.rs` to `core/tests/security_tests.rs`
- Removed `pub mod security_tests;` declaration from `core/src/lib.rs`

## Changes
This PR addresses the misplaced security test file by moving it from the source directory to the proper tests directory and updating all necessary imports and module declarations.

### Implementation Details
1. **Import Updates**: Changed all module imports from `crate::` to `balatro_rs::` format to work from tests directory
2. **File Movement**: Used `git mv` to move the file preserving history
3. **Module Declaration Cleanup**: Removed the public module declaration from `lib.rs`

## Testing
- ✅ All tests pass from new location (`cargo test -p balatro-rs`)
- ✅ Build succeeds without compilation errors (`cargo build -p balatro-rs`)
- ✅ Security tests are now properly isolated in the tests directory

## References
Closes #335

🤖 Generated with [Claude Code](https://claude.ai/code)