### PR TITLE
Fix import paths from crate::rng to balatro_rs::rng

### DIFF
--- a/core/src/game/mod.rs
+++ b/core/src/game/mod.rs
@@ -630,7 +630,6 @@ impl Game {
             if hand_result.retriggered_count > 0 {
                 write!(&mut debug_msg, " ({} retriggers)", hand_result.retriggered_count).unwrap();
             }
-            }
             messages.push(debug_msg);
         }
 

--- a/core/tests/security_tests.rs
+++ b/core/tests/security_tests.rs
@@ -192,7 +192,7 @@ mod tests {
     /// Fuzz-style test for ActionSpace creation with random values
     #[test]
     fn test_action_space_fuzz() {
-        use crate::rng::GameRng;
+        use balatro_rs::rng::GameRng;
         let rng = GameRng::for_testing(42);
 
         // Test 1000 random valid configurations
@@ -222,7 +222,7 @@ mod tests {
     /// Property-based test for arithmetic operations
     #[test]
     fn test_arithmetic_properties() {
-        use crate::rng::GameRng;
+        use balatro_rs::rng::GameRng;
         let rng = GameRng::for_testing(43);
 
         for _ in 0..100 {


### PR DESCRIPTION
## Summary
- Fixed 2 compilation errors by updating `crate::rng::GameRng` imports to `balatro_rs::rng::GameRng` in security tests
- Also resolved unrelated syntax error (extra closing brace) in game module

## Changes Made
- Updated import paths in `core/tests/security_tests.rs` (lines 195 and 225)
- Fixed syntax error in `core/src/game/mod.rs` (removed extra closing brace)

## Test Plan
- [x] Verified no remaining `crate::rng` references in test files
- [x] Confirmed compilation errors for import paths are resolved
- [x] Changes follow current project import patterns

Resolves #483

🤖 Generated with [Claude Code](https://claude.ai/code)