### PR TITLE
Fix test_half_joker test - implement hand size condition framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,21 +12,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -63,12 +64,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,15 +88,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
- "bitflags",
- "textwrap",
- "unicode-width",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
 ]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colored"
@@ -115,25 +151,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
- "atty",
+ "anes",
  "cast",
+ "ciborium",
  "clap",
  "criterion-plot",
- "csv",
- "itertools 0.10.5",
- "lazy_static",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -141,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
@@ -175,25 +208,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "csv"
-version = "1.3.1"
+name = "crunchy"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
@@ -220,9 +238,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.3"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -235,15 +257,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "indexmap"
@@ -598,16 +611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,15 +671,6 @@ name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "thiserror"
@@ -744,12 +738,6 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unindent"
@@ -848,22 +836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,12 +843,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/core/src/game/mod.rs
+++ b/core/src/game/mod.rs
@@ -630,7 +630,7 @@ impl Game {
             if hand_result.retriggered_count > 0 {
                 write!(&mut debug_msg, " ({} retriggers)", hand_result.retriggered_count).unwrap();
             }
-            }
+            
             messages.push(debug_msg);
         }
 

--- a/core/src/static_joker.rs
+++ b/core/src/static_joker.rs
@@ -20,6 +20,8 @@ pub enum StaticCondition {
     AnySuitScored(Vec<Suit>),
     /// Apply when multiple ranks are scored
     AnyRankScored(Vec<Value>),
+    /// Apply when the hand has at most the specified number of cards
+    HandSizeAtMost(usize),
 }
 
 /// A static joker that provides consistent bonuses based on conditions
@@ -145,6 +147,10 @@ impl StaticJoker {
                     HandRank::HighCard => hand.is_highcard().is_some(),
                 }
             }
+            StaticCondition::HandSizeAtMost(max_size) => {
+                // Check if the hand has at most the specified number of cards
+                hand.cards().len() <= *max_size
+            }
             _ => {
                 // For suit/rank conditions on hands, check if any card matches
                 hand.cards()
@@ -164,6 +170,10 @@ impl StaticJoker {
             StaticCondition::AnyRankScored(values) => values.contains(&card.value),
             StaticCondition::HandType(_) => {
                 // Hand type conditions don't apply to individual cards
+                false
+            }
+            StaticCondition::HandSizeAtMost(_) => {
+                // Hand size conditions don't apply to individual cards
                 false
             }
         }
@@ -249,6 +259,9 @@ impl StaticJokerBuilder {
         match (&self.condition, self.per_card) {
             (StaticCondition::HandType(_), true) => {
                 return Err("HandType conditions should be per_hand, not per_card".to_string());
+            }
+            (StaticCondition::HandSizeAtMost(_), true) => {
+                return Err("HandSizeAtMost conditions should be per_hand, not per_card".to_string());
             }
             (StaticCondition::SuitScored(_), false) => {
                 return Err("SuitScored conditions should be per_card, not per_hand".to_string());
@@ -1238,6 +1251,171 @@ mod tests {
             .condition(StaticCondition::Always)
             .per_hand()
             .build();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_hand_size_at_most_condition() {
+        let joker = StaticJoker::builder(
+            JokerId::HalfJoker,
+            "Half Joker",
+            "+20 Mult if played hand has 4 or fewer cards",
+        )
+        .mult(20)
+        .condition(StaticCondition::HandSizeAtMost(4))
+        .per_hand()
+        .build()
+        .expect("Valid joker configuration");
+
+        // Test with 4 cards (should trigger)
+        let four_card_hand = SelectHand::new(vec![
+            Card::new(Value::King, Suit::Heart),
+            Card::new(Value::Queen, Suit::Diamond),
+            Card::new(Value::Jack, Suit::Club),
+            Card::new(Value::Ten, Suit::Spade),
+        ]);
+
+        // Test with 3 cards (should trigger)
+        let three_card_hand = SelectHand::new(vec![
+            Card::new(Value::King, Suit::Heart),
+            Card::new(Value::Queen, Suit::Diamond),
+            Card::new(Value::Jack, Suit::Club),
+        ]);
+
+        // Test with 2 cards (should trigger)
+        let two_card_hand = SelectHand::new(vec![
+            Card::new(Value::King, Suit::Heart),
+            Card::new(Value::Queen, Suit::Diamond),
+        ]);
+
+        // Test with 1 card (should trigger)
+        let one_card_hand = SelectHand::new(vec![
+            Card::new(Value::King, Suit::Heart),
+        ]);
+
+        // Test with 5 cards (should NOT trigger)
+        let five_card_hand = SelectHand::new(vec![
+            Card::new(Value::King, Suit::Heart),
+            Card::new(Value::Queen, Suit::Diamond),
+            Card::new(Value::Jack, Suit::Club),
+            Card::new(Value::Ten, Suit::Spade),
+            Card::new(Value::Nine, Suit::Heart),
+        ]);
+
+        // Test with 6 cards (should NOT trigger)
+        let six_card_hand = SelectHand::new(vec![
+            Card::new(Value::King, Suit::Heart),
+            Card::new(Value::Queen, Suit::Diamond),
+            Card::new(Value::Jack, Suit::Club),
+            Card::new(Value::Ten, Suit::Spade),
+            Card::new(Value::Nine, Suit::Heart),
+            Card::new(Value::Eight, Suit::Diamond),
+        ]);
+
+        // Verify conditions
+        assert!(joker.check_hand_condition(&four_card_hand), "4 cards should trigger Half Joker");
+        assert!(joker.check_hand_condition(&three_card_hand), "3 cards should trigger Half Joker");
+        assert!(joker.check_hand_condition(&two_card_hand), "2 cards should trigger Half Joker");
+        assert!(joker.check_hand_condition(&one_card_hand), "1 card should trigger Half Joker");
+        assert!(!joker.check_hand_condition(&five_card_hand), "5 cards should NOT trigger Half Joker");
+        assert!(!joker.check_hand_condition(&six_card_hand), "6 cards should NOT trigger Half Joker");
+    }
+
+    #[test]
+    fn test_hand_size_at_most_edge_cases() {
+        // Test with 0 max size (should only trigger on empty hands)
+        let zero_joker = StaticJoker::builder(
+            JokerId::Joker,
+            "Empty Hand Joker",
+            "+10 Mult if hand is empty",
+        )
+        .mult(10)
+        .condition(StaticCondition::HandSizeAtMost(0))
+        .per_hand()
+        .build()
+        .expect("Valid joker configuration");
+
+        // Test with empty hand
+        let empty_hand = SelectHand::new(vec![]);
+        
+        // Test with one card
+        let one_card_hand = SelectHand::new(vec![
+            Card::new(Value::King, Suit::Heart),
+        ]);
+
+        assert!(zero_joker.check_hand_condition(&empty_hand), "Empty hand should trigger with max size 0");
+        assert!(!zero_joker.check_hand_condition(&one_card_hand), "1 card should NOT trigger with max size 0");
+
+        // Test with very large max size
+        let large_joker = StaticJoker::builder(
+            JokerId::Joker,
+            "Large Hand Joker",
+            "+5 Mult if hand has at most 100 cards",
+        )
+        .mult(5)
+        .condition(StaticCondition::HandSizeAtMost(100))
+        .per_hand()
+        .build()
+        .expect("Valid joker configuration");
+
+        let normal_hand = SelectHand::new(vec![
+            Card::new(Value::King, Suit::Heart),
+            Card::new(Value::Queen, Suit::Diamond),
+            Card::new(Value::Jack, Suit::Club),
+            Card::new(Value::Ten, Suit::Spade),
+            Card::new(Value::Nine, Suit::Heart),
+        ]);
+
+        assert!(large_joker.check_hand_condition(&normal_hand), "5 cards should trigger with max size 100");
+    }
+
+    #[test]
+    fn test_hand_size_at_most_with_card_condition() {
+        let joker = StaticJoker::builder(
+            JokerId::HalfJoker,
+            "Half Joker",
+            "+20 Mult if played hand has 4 or fewer cards",
+        )
+        .mult(20)
+        .condition(StaticCondition::HandSizeAtMost(4))
+        .per_hand()
+        .build()
+        .expect("Valid joker configuration");
+
+        // Hand size conditions should not apply to individual cards
+        let card = Card::new(Value::King, Suit::Heart);
+        assert!(!joker.check_card_condition(&card), "Hand size conditions should not apply to individual cards");
+    }
+
+    #[test]
+    fn test_hand_size_at_most_builder_validation() {
+        // Test that HandSizeAtMost condition with per_card fails validation
+        let result = StaticJoker::builder(
+            JokerId::HalfJoker,
+            "Invalid Half Joker",
+            "This should fail validation",
+        )
+        .mult(20)
+        .condition(StaticCondition::HandSizeAtMost(4))
+        .per_card() // This should be invalid with HandSizeAtMost
+        .build();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("HandSizeAtMost conditions should be per_hand"));
+
+        // Test that HandSizeAtMost condition with per_hand is valid
+        let result = StaticJoker::builder(
+            JokerId::HalfJoker,
+            "Valid Half Joker",
+            "This should work",
+        )
+        .mult(20)
+        .condition(StaticCondition::HandSizeAtMost(4))
+        .per_hand()
+        .build();
 
         assert!(result.is_ok());
     }

--- a/core/src/static_joker_factory.rs
+++ b/core/src/static_joker_factory.rs
@@ -455,11 +455,7 @@ impl StaticJokerFactory {
     // TODO: Implement these jokers when framework supports the required conditions
 
     /// Create Half Joker (+20 Mult if played hand has 4 or fewer cards)
-    /// TODO: Requires hand size condition in StaticCondition enum
-    /// WARNING: This is a PLACEHOLDER implementation that gives +20 Mult ALWAYS
-    /// The actual joker should only trigger with 4 or fewer cards in hand
     pub fn create_half_joker() -> Box<dyn Joker> {
-        // PLACEHOLDER: Currently provides bonus unconditionally - DO NOT USE IN PRODUCTION
         Box::new(
             StaticJoker::builder(
                 JokerId::HalfJoker,
@@ -469,7 +465,7 @@ impl StaticJokerFactory {
             .rarity(JokerRarity::Common)
             .cost(3)
             .mult(20)
-            .condition(StaticCondition::Always) // TODO: Change to HandSize(4) when available
+            .condition(StaticCondition::HandSizeAtMost(4))
             .per_hand()
             .build()
             .expect("Valid joker configuration"),

--- a/core/tests/test_additional_static_jokers.rs
+++ b/core/tests/test_additional_static_jokers.rs
@@ -2,7 +2,9 @@
 // Note: Runner is implemented as RunnerJoker in joker_impl.rs, not as a static joker
 // This file tests 9 jokers: 5 fully implemented + 4 placeholders
 
-use balatro_rs::joker::{JokerId, JokerRarity};
+use balatro_rs::card::{Card, Suit, Value};
+use balatro_rs::hand::SelectHand;
+use balatro_rs::joker::{GameContext, Joker, JokerId, JokerRarity};
 use balatro_rs::static_joker_factory::StaticJokerFactory;
 
 #[test]
@@ -74,7 +76,6 @@ fn test_walkie_joker() {
 
 // Tests for jokers that need framework extensions
 #[test]
-#[ignore] // Ignore until framework supports hand size conditions
 fn test_half_joker() {
     let joker = StaticJokerFactory::create_half_joker();
     assert_eq!(joker.id(), JokerId::HalfJoker);
@@ -85,6 +86,143 @@ fn test_half_joker() {
     );
     assert_eq!(joker.rarity(), JokerRarity::Common);
     assert_eq!(joker.cost(), 3);
+}
+
+#[test]
+fn test_half_joker_behavior_with_4_cards() {
+    let joker = StaticJokerFactory::create_half_joker();
+    let mut context = GameContext::default();
+    
+    // Test with exactly 4 cards (should trigger)
+    let four_card_hand = SelectHand::new(vec![
+        Card::new(Value::King, Suit::Heart),
+        Card::new(Value::Queen, Suit::Diamond),
+        Card::new(Value::Jack, Suit::Club),
+        Card::new(Value::Ten, Suit::Spade),
+    ]);
+    
+    let effect = joker.on_hand_played(&mut context, &four_card_hand);
+    assert_eq!(effect.mult, 20, "Half Joker should provide +20 Mult with 4 cards");
+    assert_eq!(effect.chips, 0, "Half Joker should not provide chips");
+    assert_eq!(effect.mult_multiplier, 1.0, "Half Joker should not provide mult multiplier");
+}
+
+#[test]
+fn test_half_joker_behavior_with_3_cards() {
+    let joker = StaticJokerFactory::create_half_joker();
+    let mut context = GameContext::default();
+    
+    // Test with 3 cards (should trigger)
+    let three_card_hand = SelectHand::new(vec![
+        Card::new(Value::King, Suit::Heart),
+        Card::new(Value::Queen, Suit::Diamond),
+        Card::new(Value::Jack, Suit::Club),
+    ]);
+    
+    let effect = joker.on_hand_played(&mut context, &three_card_hand);
+    assert_eq!(effect.mult, 20, "Half Joker should provide +20 Mult with 3 cards");
+}
+
+#[test]
+fn test_half_joker_behavior_with_2_cards() {
+    let joker = StaticJokerFactory::create_half_joker();
+    let mut context = GameContext::default();
+    
+    // Test with 2 cards (should trigger)
+    let two_card_hand = SelectHand::new(vec![
+        Card::new(Value::King, Suit::Heart),
+        Card::new(Value::Queen, Suit::Diamond),
+    ]);
+    
+    let effect = joker.on_hand_played(&mut context, &two_card_hand);
+    assert_eq!(effect.mult, 20, "Half Joker should provide +20 Mult with 2 cards");
+}
+
+#[test]
+fn test_half_joker_behavior_with_1_card() {
+    let joker = StaticJokerFactory::create_half_joker();
+    let mut context = GameContext::default();
+    
+    // Test with 1 card (should trigger)
+    let one_card_hand = SelectHand::new(vec![
+        Card::new(Value::King, Suit::Heart),
+    ]);
+    
+    let effect = joker.on_hand_played(&mut context, &one_card_hand);
+    assert_eq!(effect.mult, 20, "Half Joker should provide +20 Mult with 1 card");
+}
+
+#[test]
+fn test_half_joker_behavior_with_5_cards() {
+    let joker = StaticJokerFactory::create_half_joker();
+    let mut context = GameContext::default();
+    
+    // Test with 5 cards (should NOT trigger)
+    let five_card_hand = SelectHand::new(vec![
+        Card::new(Value::King, Suit::Heart),
+        Card::new(Value::Queen, Suit::Diamond),
+        Card::new(Value::Jack, Suit::Club),
+        Card::new(Value::Ten, Suit::Spade),
+        Card::new(Value::Nine, Suit::Heart),
+    ]);
+    
+    let effect = joker.on_hand_played(&mut context, &five_card_hand);
+    assert_eq!(effect.mult, 0, "Half Joker should provide no mult with 5 cards");
+    assert_eq!(effect.chips, 0, "Half Joker should provide no chips with 5 cards");
+    assert_eq!(effect.mult_multiplier, 1.0, "Half Joker should provide no mult multiplier with 5 cards");
+}
+
+#[test]
+fn test_half_joker_behavior_with_6_cards() {
+    let joker = StaticJokerFactory::create_half_joker();
+    let mut context = GameContext::default();
+    
+    // Test with 6 cards (should NOT trigger)
+    let six_card_hand = SelectHand::new(vec![
+        Card::new(Value::King, Suit::Heart),
+        Card::new(Value::Queen, Suit::Diamond),
+        Card::new(Value::Jack, Suit::Club),
+        Card::new(Value::Ten, Suit::Spade),
+        Card::new(Value::Nine, Suit::Heart),
+        Card::new(Value::Eight, Suit::Diamond),
+    ]);
+    
+    let effect = joker.on_hand_played(&mut context, &six_card_hand);
+    assert_eq!(effect.mult, 0, "Half Joker should provide no mult with 6 cards");
+}
+
+#[test]
+fn test_half_joker_behavior_per_hand_not_per_card() {
+    let joker = StaticJokerFactory::create_half_joker();
+    let mut context = GameContext::default();
+    
+    // Test that Half Joker is per-hand, not per-card
+    let three_card_hand = SelectHand::new(vec![
+        Card::new(Value::King, Suit::Heart),
+        Card::new(Value::Queen, Suit::Diamond),
+        Card::new(Value::Jack, Suit::Club),
+    ]);
+    
+    // Test on_card_scored - should return no effect since it's per-hand
+    let card = Card::new(Value::King, Suit::Heart);
+    let card_effect = joker.on_card_scored(&mut context, &card);
+    assert_eq!(card_effect.mult, 0, "Half Joker should not trigger on individual cards");
+    
+    // Test on_hand_played - should return effect since it's per-hand
+    let hand_effect = joker.on_hand_played(&mut context, &three_card_hand);
+    assert_eq!(hand_effect.mult, 20, "Half Joker should trigger on hands with ≤4 cards");
+}
+
+#[test]
+fn test_half_joker_behavior_edge_case_empty_hand() {
+    let joker = StaticJokerFactory::create_half_joker();
+    let mut context = GameContext::default();
+    
+    // Test with empty hand (should trigger as 0 ≤ 4)
+    let empty_hand = SelectHand::new(vec![]);
+    
+    let effect = joker.on_hand_played(&mut context, &empty_hand);
+    assert_eq!(effect.mult, 20, "Half Joker should provide +20 Mult with empty hand");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Implements hand size condition support in the joker framework for issue #498
- Fixes the ignored `test_half_joker` test by adding `HandSizeAtMost` condition
- Half Joker now correctly provides +20 Mult only when hand has ≤4 cards

## Changes Made
- **Added `HandSizeAtMost(usize)` to `StaticCondition` enum** - New condition type for checking hand size limits
- **Implemented hand size checking logic** - Added logic in `check_hand_condition` to validate hand size
- **Added builder validation** - Ensures `HandSizeAtMost` can only be used with `per_hand` (not `per_card`)
- **Updated Half Joker factory** - Changed from placeholder `Always` condition to proper `HandSizeAtMost(4)`
- **Removed `#[ignore]` from test** - The `test_half_joker` test now runs successfully
- **Added comprehensive tests** - New tests verify hand size condition works with different hand sizes
- **Fixed minor syntax error** - Removed extra closing brace in `game/mod.rs`

## Test Coverage
- ✅ Hand size condition works with 1, 2, 3, and 4 cards (triggers)
- ✅ Hand size condition correctly rejects 5+ cards (doesn't trigger)
- ✅ Builder validation prevents invalid `per_card` usage
- ✅ Edge cases handled (empty hands, large max sizes)
- ✅ Half Joker provides exact +20 Mult when condition is met

## Framework Extension
The new `HandSizeAtMost` condition is reusable for other jokers that need hand size checking, following the same pattern as existing conditions like `HandType` and `SuitScored`.

Fixes #498

🤖 Generated with [Claude Code](https://claude.ai/code)