### PR TITLE
Fix remaining compilation errors after emergency PR merge

### DIFF
--- a/core/src/joker/test_utils.rs
+++ b/core/src/joker/test_utils.rs
@@ -609,10 +609,10 @@ impl TestContextBuilder {
             money: 5,
             ante: 1,
             round: 1,
-            stage: Stage::Blind,
+            stage: Stage::Blind(crate::stage::Blind::Small),
             hands_played: 0,
             discards_used: 0,
-            hand: Hand::new(),
+            hand: Hand::new(vec![]),
             discarded: Vec::new(),
             hand_type_counts: HashMap::new(),
             cards_in_deck: 52,
@@ -842,11 +842,7 @@ pub fn create_test_card(rank: Value, suit: Suit) -> Card {
 
 /// Create a simple test hand with specified cards.
 pub fn create_test_hand(cards: Vec<Card>) -> Hand {
-    let mut hand = Hand::new();
-    for card in cards {
-        hand.add(card);
-    }
-    hand
+    Hand::new(cards)
 }
 
 #[cfg(test)]
@@ -956,7 +952,7 @@ mod tests {
         let state = JokerState::new();
 
         let serialized = joker.serialize_state(&context, &state).unwrap();
-        assert_eq!(serialized["custom_serialization"], Value::Bool(true));
+        assert_eq!(serialized["custom_serialization"], JsonValue::Bool(true));
     }
 
     #[test]
@@ -1009,7 +1005,7 @@ mod tests {
             .with_money(100)
             .with_ante(5)
             .with_round(12)
-            .with_stage(Stage::Shop)
+            .with_stage(Stage::Shop())
             .with_hands_played(3)
             .with_discards_used(2)
             .with_hand_type_count(HandRank::OnePair, 5)
@@ -1022,7 +1018,7 @@ mod tests {
         assert_eq!(context.money, 100);
         assert_eq!(context.ante, 5);
         assert_eq!(context.round, 12);
-        assert_eq!(*context.stage, Stage::Shop);
+        assert_eq!(*context.stage, Stage::Shop());
         assert_eq!(context.hands_played, 3);
         assert_eq!(context.discards_used, 2);
         assert_eq!(context.get_hand_type_count(HandRank::OnePair), 5);

--- a/core/src/joker_effect_processor.rs
+++ b/core/src/joker_effect_processor.rs
@@ -1524,23 +1524,12 @@ mod tests {
             rng: &crate::rng::GameRng::secure(),
         };
 
-        let hand = SelectHand {
-            cards: vec![
-                Card {
-                    value: Value::Ace,
-                    suit: Suit::Hearts,
-                },
-                Card {
-                    value: Value::King,
-                    suit: Suit::Hearts,
-                },
-            ],
-        };
+        let hand = SelectHand::new(vec![
+            Card::new(Value::Ace, Suit::Heart),
+            Card::new(Value::King, Suit::Heart),
+        ]);
 
-        let card = Card {
-            value: Value::Queen,
-            suit: Suit::Spades,
-        };
+        let card = Card::new(Value::Queen, Suit::Spade);
 
         let jokers: Vec<Box<dyn crate::joker::Joker>> = vec![];
 
@@ -1760,6 +1749,17 @@ mod tests {
         let mut config = CacheConfig::default();
         config.enabled = false;
         processor_without_cache.set_cache_config(config);
+        // Create long-lived values for the context
+        let stage = Box::leak(Box::new(crate::stage::Stage::PreBlind()));
+        let hand = Box::leak(Box::new(crate::hand::Hand::new(vec![])));
+        let discarded: &'static [Card] = Box::leak(Box::new([]));
+        let state_manager = Box::leak(Box::new(std::sync::Arc::new(
+            crate::joker_state::JokerStateManager::new(),
+        )));
+        let hand_counts = Box::leak(Box::new(HashMap::new()));
+        let rng = Box::leak(Box::new(crate::rng::GameRng::secure()));
+        let jokers: &'static [Box<dyn crate::joker::Joker>] = Box::leak(Box::new([]));
+
         // Helper function to create fresh GameContext instances
         let create_game_context = || -> GameContext {
             GameContext {
@@ -1768,46 +1768,27 @@ mod tests {
                 money: 100,
                 ante: 1,
                 round: 1,
-                stage: &crate::stage::Stage::PreBlind(),
+                stage,
                 hands_played: 0,
                 discards_used: 0,
-                jokers: &[],
-                hand: &crate::hand::Hand::new(vec![]),
-                discarded: &[],
-                joker_state_manager: &std::sync::Arc::new(
-                    crate::joker_state::JokerStateManager::new(),
-                ),
-                hand_type_counts: &HashMap::new(),
+                jokers,
+                hand,
+                discarded,
+                joker_state_manager: state_manager,
+                hand_type_counts: hand_counts,
                 cards_in_deck: 52,
                 stone_cards_in_deck: 0,
-                rng: &crate::rng::GameRng::secure(),
+                rng,
             }
         };
 
-        let hand = SelectHand {
-            cards: vec![
-                Card {
-                    value: Value::Ace,
-                    suit: Suit::Hearts,
-                },
-                Card {
-                    value: Value::King,
-                    suit: Suit::Hearts,
-                },
-                Card {
-                    value: Value::Queen,
-                    suit: Suit::Hearts,
-                },
-                Card {
-                    value: Value::Jack,
-                    suit: Suit::Hearts,
-                },
-                Card {
-                    value: Value::Ten,
-                    suit: Suit::Hearts,
-                },
-            ],
-        };
+        let hand = SelectHand::new(vec![
+            Card::new(Value::Ace, Suit::Heart),
+            Card::new(Value::King, Suit::Heart),
+            Card::new(Value::Queen, Suit::Heart),
+            Card::new(Value::Jack, Suit::Heart),
+            Card::new(Value::Ten, Suit::Heart),
+        ]);
 
         let jokers: Vec<Box<dyn crate::joker::Joker>> = vec![];
 
@@ -1875,23 +1856,12 @@ mod tests {
             rng: &crate::rng::GameRng::secure(),
         };
 
-        let hand = SelectHand {
-            cards: vec![
-                Card {
-                    value: Value::Ace,
-                    suit: Suit::Hearts,
-                },
-                Card {
-                    value: Value::King,
-                    suit: Suit::Hearts,
-                },
-            ],
-        };
+        let hand = SelectHand::new(vec![
+            Card::new(Value::Ace, Suit::Heart),
+            Card::new(Value::King, Suit::Heart),
+        ]);
 
-        let card = Card {
-            value: Value::Queen,
-            suit: Suit::Spades,
-        };
+        let card = Card::new(Value::Queen, Suit::Spade);
 
         let jokers: Vec<Box<dyn crate::joker::Joker>> = vec![];
 
@@ -2223,7 +2193,7 @@ mod tests {
     fn test_priority_strategy_api_from_issue() {
         // Test the exact API proposed in the issue
         let context = ProcessingContext::builder()
-            .priority_strategy(Arc::new(MetadataPriorityStrategy::new()))
+            .priority_strategy(Arc::new(MetadataPriorityStrategy::default()))
             .build();
 
         let processor = JokerEffectProcessor::with_context(context);

--- a/core/src/scaling_joker.rs
+++ b/core/src/scaling_joker.rs
@@ -393,7 +393,7 @@ mod tests {
     #[test]
     fn test_scaling_trigger_display() {
         assert_eq!(
-            format!("{}", ScalingTrigger::HandPlayed(HandRank::Pair)),
+            format!("{}", ScalingTrigger::HandPlayed(HandRank::OnePair)),
             "Pair played"
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- Fixed all remaining compilation errors that appeared after merging emergency PR #555
- Resolved API compatibility issues between different parts of the codebase
- Updated test utilities to use correct types and constructors

## Changes Made
- **Stage constructors**: Fixed `Stage::Blind(Default::default())` to use specific `Blind::Small` variant
- **Type system fixes**: Resolved `Hand`/`SelectHand` type mismatches in test contexts
- **Trait disambiguition**: Fixed method ambiguity between `JokerIdentity` and `Joker` traits
- **RNG initialization**: Fixed `GameRng::new()` calls to include required `RngMode` parameter
- **Enum variants**: Corrected `HandRank::Pair` to `HandRank::OnePair`
- **Constructor calls**: Fixed `MetadataPriorityStrategy::new()` to use `default()`
- **Visibility issues**: Resolved `SelectHand` constructor accessibility problems
- **Lifetime management**: Fixed lifetime issues in tests using `Box::leak` pattern

## Test Results
✅ All compilation errors resolved
✅ `cargo test --lib` now compiles successfully
✅ `cargo clippy --all -- -D warnings` passes without issues

## Files Modified
- `core/src/joker/test_utils.rs`: Updated test helper functions and context builders
- `core/src/special_jokers.rs`: Fixed trait method calls and test setup
- `core/src/joker_effect_processor.rs`: Resolved lifetime issues in test functions
- `core/src/scaling_joker.rs`: Fixed enum variant reference

## Impact
This PR restores full compilation capability to the codebase after the emergency CI fixes, ensuring all tests can be built and run properly.

🤖 Generated with [Claude Code](https://claude.ai/code)