### PR TITLE
Fix benchmark compilation failures

### DIFF
--- a/core/benches/trait_benchmark_minimal.rs
+++ b/core/benches/trait_benchmark_minimal.rs
@@ -17,9 +17,7 @@ pub fn minimal_trait_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             // Test joker registry access
-            if let Ok(Some(definition)) = joker_registry::registry::get_definition(&JokerId::Joker)
-            {
-                let joker = joker_registry::JokerRegistry::create_joker(&JokerId::Joker).unwrap();
+            if let Ok(joker) = joker_registry::registry::create_joker(&JokerId::Joker) {
                 black_box(joker.id());
             }
             black_box(&test_card);


### PR DESCRIPTION
## Summary
- Fixed all benchmark compilation errors that were preventing benchmarks from building
- Benchmarks were using outdated APIs from before the trait refactoring
- All benchmarks now compile and can be run with `cargo bench`

## Changes
- Replace static `JokerRegistry::create_joker()` calls with `joker_registry::registry::create_joker()`
- Fix `GameContext` lifetime issues by introducing `TestGameData` struct to own data
- Replace `HandType` with `HandRank` and fix imports
- Update `process_*_optimized` method calls to match current API

## Test plan
- [x] Run `cargo bench --no-run -p balatro-rs` - all benchmarks compile successfully
- [x] Run `cargo test --no-run -p balatro-rs` - tests still compile
- [x] Run `cargo fmt` - code is formatted

🤖 Generated with [Claude Code](https://claude.ai/code)