### PR TITLE
Fix gh-pages deployment permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ env:
   CARGO_TERM_COLOR: always
 
 permissions:
-  contents: read
+  contents: write  # Changed from read to write for gh-pages deployment
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- Fixed the documentation deployment workflow that was failing with 403 permission denied
- The peaceiris/actions-gh-pages action needs `contents: write` permission to push to gh-pages branch

## Problem
The docs workflow was failing on main branch pushes with:
```
remote: Permission to spencerduncan/balatro-rs.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/spencerduncan/balatro-rs.git/': The requested URL returned error: 403
```

## Solution
Changed workflow permissions from `contents: read` to `contents: write` to allow the action to push to gh-pages branch.

## Test plan
- [x] Updated permissions in docs.yml
- [ ] Merge to main and verify docs deployment succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)