### PR TITLE
CI: Skip performance tests for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,8 @@ jobs:
   # Run performance benchmarks and validate against baselines
   performance-test:
     name: Performance Testing
+    # Only run performance tests on pushes to main/master, not on PRs
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     container:
       image: rust:latest


### PR DESCRIPTION
## Summary
- Modified CI workflow to skip performance tests for pull requests
- Performance tests now only run on pushes to main/master branches
- This reduces CI time for PRs while maintaining performance checks post-merge

## Test plan
- [x] Verify CI configuration syntax is valid
- [ ] Confirm performance tests are skipped on this PR
- [ ] Confirm other CI checks still run normally on PRs
- [ ] Verify performance tests will run on merge to main

🤖 Generated with [Claude Code](https://claude.ai/code)