### PR TITLE
fix(#144): Implement stateful Ride the Bus joker with reset mechanism

### DIFF
--- a/core/src/joker/hand_composition_jokers.rs
+++ b/core/src/joker/hand_composition_jokers.rs
@@ -1,22 +1,16 @@
 use crate::{
-    card::Card,
+    card::{Card, Value},
     hand::SelectHand,
     joker::{
         ConditionalJoker, GameContext, Joker, JokerCondition, JokerEffect, JokerId, JokerRarity,
     },
+    joker_state::JokerState,
 };
 
 /// Factory function for Ride the Bus joker
-/// "+1 mult per hand without face card"
-pub fn create_ride_the_bus() -> ConditionalJoker {
-    ConditionalJoker::new(
-        JokerId::Ride,
-        "Ride the Bus",
-        "+1 mult per hand without face card",
-        JokerRarity::Common,
-        JokerCondition::NoFaceCardsHeld,
-        JokerEffect::new().with_mult(1),
-    )
+/// "+1 mult per hand without face card (resets when face card scored)"
+pub fn create_ride_the_bus() -> Box<dyn Joker> {
+    create_ride_the_bus_stateful()
 }
 
 /// Factory function for Blackboard joker
@@ -125,6 +119,122 @@ impl Joker for DnaJoker {
 /// "Copy first card if only 1 in hand"
 pub fn create_dna() -> Box<dyn Joker> {
     Box::new(DnaJoker::new())
+}
+
+/// Stateful Ride the Bus joker implementation
+#[derive(Debug, Clone)]
+pub struct RideTheBusStateful {
+    pub id: JokerId,
+    pub name: String,
+    pub description: String,
+    pub rarity: JokerRarity,
+    pub cost: usize,
+}
+
+impl Default for RideTheBusStateful {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RideTheBusStateful {
+    pub fn new() -> Self {
+        Self {
+            id: JokerId::Ride,
+            name: "Ride the Bus".to_string(),
+            description: "+1 mult per hand without face card (resets when face card scored)".to_string(),
+            rarity: JokerRarity::Common,
+            cost: 3,
+        }
+    }
+    
+    /// Check if a card is a face card (Jack, Queen, or King)
+    fn is_face_card(card: &Card) -> bool {
+        matches!(card.value, Value::Jack | Value::Queen | Value::King)
+    }
+    
+    /// Check if a hand contains any face cards
+    fn hand_has_face_cards(hand: &SelectHand) -> bool {
+        hand.cards().iter().any(|card| Self::is_face_card(card))
+    }
+}
+
+impl Joker for RideTheBusStateful {
+    fn id(&self) -> JokerId {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn rarity(&self) -> JokerRarity {
+        self.rarity
+    }
+
+    fn cost(&self) -> usize {
+        self.cost
+    }
+
+    fn on_hand_played(&self, context: &mut GameContext, hand: &SelectHand) -> JokerEffect {
+        // Increment accumulated value only if hand has no face cards
+        if !Self::hand_has_face_cards(hand) {
+            context
+                .joker_state_manager
+                .update_state(self.id(), |state| {
+                    state.accumulated_value += 1.0;
+                });
+        }
+
+        // Always return current accumulated value as mult bonus
+        let current_mult = context
+            .joker_state_manager
+            .get_accumulated_value(self.id())
+            .unwrap_or(0.0) as i32;
+        
+        JokerEffect::new().with_mult(current_mult)
+    }
+
+    fn on_card_scored(&self, context: &mut GameContext, card: &Card) -> JokerEffect {
+        // Reset accumulated value if a face card is scored
+        if Self::is_face_card(card) {
+            context
+                .joker_state_manager
+                .update_state(self.id(), |state| {
+                    state.accumulated_value = 0.0;
+                });
+        }
+        JokerEffect::new()
+    }
+
+    fn on_blind_start(&self, _context: &mut GameContext) -> JokerEffect {
+        JokerEffect::new()
+    }
+
+    fn on_shop_open(&self, _context: &mut GameContext) -> JokerEffect {
+        JokerEffect::new()
+    }
+
+    fn on_discard(&self, _context: &mut GameContext, _cards: &[Card]) -> JokerEffect {
+        JokerEffect::new()
+    }
+
+    fn on_round_end(&self, _context: &mut GameContext) -> JokerEffect {
+        JokerEffect::new()
+    }
+
+    fn initialize_state(&self, _context: &GameContext) -> JokerState {
+        JokerState::with_accumulated_value(0.0)
+    }
+}
+
+/// Factory function for stateful Ride the Bus joker
+pub fn create_ride_the_bus_stateful() -> Box<dyn Joker> {
+    Box::new(RideTheBusStateful::new())
 }
 
 #[cfg(test)]

--- a/core/src/joker/hand_composition_jokers.rs
+++ b/core/src/joker/hand_composition_jokers.rs
@@ -142,20 +142,21 @@ impl RideTheBusStateful {
         Self {
             id: JokerId::Ride,
             name: "Ride the Bus".to_string(),
-            description: "+1 mult per hand without face card (resets when face card scored)".to_string(),
+            description: "+1 mult per hand without face card (resets when face card scored)"
+                .to_string(),
             rarity: JokerRarity::Common,
             cost: 3,
         }
     }
-    
+
     /// Check if a card is a face card (Jack, Queen, or King)
     fn is_face_card(card: &Card) -> bool {
         matches!(card.value, Value::Jack | Value::Queen | Value::King)
     }
-    
+
     /// Check if a hand contains any face cards
     fn hand_has_face_cards(hand: &SelectHand) -> bool {
-        hand.cards().iter().any(|card| Self::is_face_card(card))
+        hand.cards().iter().any(Self::is_face_card)
     }
 }
 
@@ -195,7 +196,7 @@ impl Joker for RideTheBusStateful {
             .joker_state_manager
             .get_accumulated_value(self.id())
             .unwrap_or(0.0) as i32;
-        
+
         JokerEffect::new().with_mult(current_mult)
     }
 

--- a/core/src/joker/hand_composition_tests.rs
+++ b/core/src/joker/hand_composition_tests.rs
@@ -11,6 +11,265 @@ use crate::{
 #[cfg(test)]
 mod ride_the_bus_tests {
     use super::*;
+    use crate::joker::{GameContext, Joker};
+    use crate::joker::hand_composition_jokers::{create_ride_the_bus, create_ride_the_bus_stateful};
+    use crate::joker_state::JokerStateManager;
+
+    #[test]
+    fn test_ride_the_bus_accumulates_mult_without_face_cards() {
+        // Create stateful Ride the Bus joker
+        let joker = create_ride_the_bus_stateful();
+        let mut context = create_test_context();
+        
+        // Initialize joker state
+        context.joker_state_manager.set_state(
+            joker.id(),
+            joker.initialize_state(&context)
+        );
+
+        // First hand without face cards - should give +1 mult
+        let hand1 = SelectHand::new(vec![
+            Card::new(Rank::Ace, Suit::Heart),
+            Card::new(Rank::Two, Suit::Spade),
+            Card::new(Rank::Ten, Suit::Diamond),
+        ]);
+        let effect1 = joker.on_hand_played(&mut context, &hand1);
+        assert_eq!(effect1.mult, 1);
+
+        // Second hand without face cards - should accumulate to +2 mult
+        let hand2 = SelectHand::new(vec![
+            Card::new(Rank::Three, Suit::Heart),
+            Card::new(Rank::Four, Suit::Spade),
+            Card::new(Rank::Five, Suit::Diamond),
+        ]);
+        let effect2 = joker.on_hand_played(&mut context, &hand2);
+        assert_eq!(effect2.mult, 2);
+
+        // Third hand without face cards - should accumulate to +3 mult
+        let hand3 = SelectHand::new(vec![
+            Card::new(Rank::Six, Suit::Heart),
+            Card::new(Rank::Seven, Suit::Spade),
+            Card::new(Rank::Eight, Suit::Diamond),
+        ]);
+        let effect3 = joker.on_hand_played(&mut context, &hand3);
+        assert_eq!(effect3.mult, 3);
+    }
+
+    #[test]
+    fn test_ride_the_bus_resets_when_face_card_scored() {
+        // Create stateful Ride the Bus joker
+        let joker = create_ride_the_bus_stateful();
+        let mut context = create_test_context();
+        
+        // Initialize joker state
+        context.joker_state_manager.set_state(
+            joker.id(),
+            joker.initialize_state(&context)
+        );
+
+        // Play two hands without face cards to accumulate mult
+        let hand1 = SelectHand::new(vec![
+            Card::new(Rank::Ace, Suit::Heart),
+            Card::new(Rank::Two, Suit::Spade),
+        ]);
+        joker.on_hand_played(&mut context, &hand1);
+        
+        let hand2 = SelectHand::new(vec![
+            Card::new(Rank::Three, Suit::Heart),
+            Card::new(Rank::Four, Suit::Spade),
+        ]);
+        let effect2 = joker.on_hand_played(&mut context, &hand2);
+        assert_eq!(effect2.mult, 2); // Should have accumulated to 2
+
+        // Score a face card - should reset accumulated mult
+        let face_card = Card::new(Rank::King, Suit::Heart);
+        joker.on_card_scored(&mut context, &face_card);
+
+        // Next hand without face cards should start from 1 again
+        let hand3 = SelectHand::new(vec![
+            Card::new(Rank::Five, Suit::Heart),
+            Card::new(Rank::Six, Suit::Spade),
+        ]);
+        let effect3 = joker.on_hand_played(&mut context, &hand3);
+        assert_eq!(effect3.mult, 1); // Reset to 1
+    }
+
+    #[test]
+    fn test_ride_the_bus_does_not_increment_with_face_cards_in_hand() {
+        // Create stateful Ride the Bus joker
+        let joker = create_ride_the_bus_stateful();
+        let mut context = create_test_context();
+        
+        // Initialize joker state
+        context.joker_state_manager.set_state(
+            joker.id(),
+            joker.initialize_state(&context)
+        );
+
+        // First hand without face cards
+        let hand1 = SelectHand::new(vec![
+            Card::new(Rank::Ace, Suit::Heart),
+            Card::new(Rank::Two, Suit::Spade),
+        ]);
+        let effect1 = joker.on_hand_played(&mut context, &hand1);
+        assert_eq!(effect1.mult, 1);
+
+        // Hand with face card - should not increment but keep current value
+        let hand_with_face = SelectHand::new(vec![
+            Card::new(Rank::Jack, Suit::Heart),
+            Card::new(Rank::Two, Suit::Spade),
+        ]);
+        let effect_face = joker.on_hand_played(&mut context, &hand_with_face);
+        assert_eq!(effect_face.mult, 1); // Should stay at 1, not increment
+
+        // Another hand without face cards - should increment from 1 to 2
+        let hand3 = SelectHand::new(vec![
+            Card::new(Rank::Three, Suit::Heart),
+            Card::new(Rank::Four, Suit::Spade),
+        ]);
+        let effect3 = joker.on_hand_played(&mut context, &hand3);
+        assert_eq!(effect3.mult, 2);
+    }
+
+    #[test]
+    fn test_ride_the_bus_resets_on_any_face_card_scored() {
+        // Create stateful Ride the Bus joker
+        let joker = create_ride_the_bus_stateful();
+        let mut context = create_test_context();
+        
+        // Initialize joker state
+        context.joker_state_manager.set_state(
+            joker.id(),
+            joker.initialize_state(&context)
+        );
+
+        // Build up some accumulated mult
+        for _ in 0..3 {
+            let hand = SelectHand::new(vec![
+                Card::new(Rank::Ace, Suit::Heart),
+                Card::new(Rank::Two, Suit::Spade),
+            ]);
+            joker.on_hand_played(&mut context, &hand);
+        }
+
+        // Test Jack resets
+        let jack = Card::new(Rank::Jack, Suit::Heart);
+        joker.on_card_scored(&mut context, &jack);
+        let hand = SelectHand::new(vec![Card::new(Rank::Two, Suit::Heart)]);
+        let effect = joker.on_hand_played(&mut context, &hand);
+        assert_eq!(effect.mult, 1);
+
+        // Build up again and test Queen resets
+        joker.on_hand_played(&mut context, &hand);
+        let queen = Card::new(Rank::Queen, Suit::Spade);
+        joker.on_card_scored(&mut context, &queen);
+        let effect2 = joker.on_hand_played(&mut context, &hand);
+        assert_eq!(effect2.mult, 1);
+
+        // Build up again and test King resets
+        joker.on_hand_played(&mut context, &hand);
+        let king = Card::new(Rank::King, Suit::Diamond);
+        joker.on_card_scored(&mut context, &king);
+        let effect3 = joker.on_hand_played(&mut context, &hand);
+        assert_eq!(effect3.mult, 1);
+    }
+
+    #[test]
+    fn test_ride_the_bus_scoring_non_face_card_does_not_reset() {
+        // Create stateful Ride the Bus joker
+        let joker = create_ride_the_bus_stateful();
+        let mut context = create_test_context();
+        
+        // Initialize joker state
+        context.joker_state_manager.set_state(
+            joker.id(),
+            joker.initialize_state(&context)
+        );
+
+        // Build up accumulated mult
+        for _ in 0..3 {
+            let hand = SelectHand::new(vec![
+                Card::new(Rank::Two, Suit::Heart),
+                Card::new(Rank::Three, Suit::Spade),
+            ]);
+            joker.on_hand_played(&mut context, &hand);
+        }
+
+        // Score non-face cards - should not reset
+        let ace = Card::new(Rank::Ace, Suit::Heart);
+        joker.on_card_scored(&mut context, &ace);
+        
+        let ten = Card::new(Rank::Ten, Suit::Spade);
+        joker.on_card_scored(&mut context, &ten);
+
+        // Next hand should continue accumulating
+        let hand = SelectHand::new(vec![Card::new(Rank::Two, Suit::Heart)]);
+        let effect = joker.on_hand_played(&mut context, &hand);
+        assert_eq!(effect.mult, 4); // Should be 4, not reset
+    }
+
+    #[test]
+    fn test_ride_the_bus_empty_hand_behavior() {
+        // Create stateful Ride the Bus joker
+        let joker = create_ride_the_bus_stateful();
+        let mut context = create_test_context();
+        
+        // Initialize joker state
+        context.joker_state_manager.set_state(
+            joker.id(),
+            joker.initialize_state(&context)
+        );
+
+        // Empty hand has no face cards, so should increment
+        let empty_hand = SelectHand::new(vec![]);
+        let effect = joker.on_hand_played(&mut context, &empty_hand);
+        assert_eq!(effect.mult, 1);
+
+        // Another empty hand
+        let effect2 = joker.on_hand_played(&mut context, &empty_hand);
+        assert_eq!(effect2.mult, 2);
+    }
+
+    // Helper function to create test context
+    fn create_test_context() -> GameContext<'static> {
+        use std::sync::{Arc, OnceLock};
+        use crate::hand::Hand;
+        use crate::stage::{Stage, Blind};
+        use crate::rank::HandRank;
+        use std::collections::HashMap;
+        
+        static STAGE: Stage = Stage::Blind(Blind::Small);
+        static HAND: OnceLock<Hand> = OnceLock::new();
+        let hand = HAND.get_or_init(|| Hand::new(Vec::new()));
+
+        static HAND_TYPE_COUNTS: OnceLock<HashMap<HandRank, u32>> = OnceLock::new();
+        let hand_type_counts = HAND_TYPE_COUNTS.get_or_init(|| HashMap::new());
+
+        // Create a new state manager for each test to avoid cross-test contamination
+        let joker_state_manager = Box::leak(Box::new(Arc::new(JokerStateManager::new())));
+
+        static TEST_RNG: OnceLock<crate::rng::GameRng> = OnceLock::new();
+        let rng = TEST_RNG.get_or_init(|| crate::rng::GameRng::for_testing(42));
+        
+        GameContext {
+            chips: 0,
+            mult: 1,
+            money: 0,
+            ante: 1,
+            round: 1,
+            stage: &STAGE,
+            hands_played: 0,
+            discards_used: 0,
+            jokers: &[],
+            hand,
+            discarded: &[],
+            joker_state_manager,
+            hand_type_counts,
+            cards_in_deck: 52,
+            stone_cards_in_deck: 0,
+            rng,
+        }
+    }
 
     #[test]
     fn test_ride_the_bus_condition_no_face_cards() {
@@ -32,6 +291,63 @@ mod ride_the_bus_tests {
             .any(|card| matches!(card.value, Rank::Jack | Rank::Queen | Rank::King));
 
         assert!(!has_face_cards); // Should have no face cards
+    }
+    
+    #[test]
+    fn test_ride_the_bus_factory_compatibility() {
+        // Test that the old factory function returns a stateful joker
+        let joker = create_ride_the_bus();
+        let mut context = create_test_context();
+        
+        // Initialize joker state
+        context.joker_state_manager.set_state(
+            joker.id(),
+            joker.initialize_state(&context)
+        );
+        
+        // Should work the same as stateful version
+        let hand = SelectHand::new(vec![Card::new(Rank::Two, Suit::Heart)]);
+        let effect = joker.on_hand_played(&mut context, &hand);
+        assert_eq!(effect.mult, 1);
+        
+        // Score a face card and verify reset
+        let king = Card::new(Rank::King, Suit::Spade);
+        joker.on_card_scored(&mut context, &king);
+        
+        let effect2 = joker.on_hand_played(&mut context, &hand);
+        assert_eq!(effect2.mult, 1); // Should have reset
+    }
+    
+    #[test]
+    fn test_ride_the_bus_state_persistence() {
+        // Test that state persists correctly
+        let joker = create_ride_the_bus_stateful();
+        let mut context = create_test_context();
+        
+        // Initialize and get initial state
+        let initial_state = joker.initialize_state(&context);
+        context.joker_state_manager.set_state(joker.id(), initial_state.clone());
+        
+        // Play some hands to accumulate state
+        let hand = SelectHand::new(vec![Card::new(Rank::Two, Suit::Heart)]);
+        for _ in 0..3 {
+            joker.on_hand_played(&mut context, &hand);
+        }
+        
+        // Get current state
+        let current_state = context.joker_state_manager.get_state(joker.id()).unwrap();
+        assert_eq!(current_state.accumulated_value, 3.0);
+        
+        // Simulate saving and loading state
+        let saved_state = current_state.clone();
+        
+        // Create new context and restore state
+        let mut new_context = create_test_context();
+        new_context.joker_state_manager.set_state(joker.id(), saved_state);
+        
+        // Should continue from saved state
+        let effect = joker.on_hand_played(&mut new_context, &hand);
+        assert_eq!(effect.mult, 4); // 3 + 1
     }
 
     #[test]

--- a/core/src/joker/hand_composition_tests.rs
+++ b/core/src/joker/hand_composition_tests.rs
@@ -11,8 +11,10 @@ use crate::{
 #[cfg(test)]
 mod ride_the_bus_tests {
     use super::*;
+    use crate::joker::hand_composition_jokers::{
+        create_ride_the_bus, create_ride_the_bus_stateful,
+    };
     use crate::joker::{GameContext, Joker};
-    use crate::joker::hand_composition_jokers::{create_ride_the_bus, create_ride_the_bus_stateful};
     use crate::joker_state::JokerStateManager;
 
     #[test]
@@ -20,12 +22,11 @@ mod ride_the_bus_tests {
         // Create stateful Ride the Bus joker
         let joker = create_ride_the_bus_stateful();
         let mut context = create_test_context();
-        
+
         // Initialize joker state
-        context.joker_state_manager.set_state(
-            joker.id(),
-            joker.initialize_state(&context)
-        );
+        context
+            .joker_state_manager
+            .set_state(joker.id(), joker.initialize_state(&context));
 
         // First hand without face cards - should give +1 mult
         let hand1 = SelectHand::new(vec![
@@ -60,12 +61,11 @@ mod ride_the_bus_tests {
         // Create stateful Ride the Bus joker
         let joker = create_ride_the_bus_stateful();
         let mut context = create_test_context();
-        
+
         // Initialize joker state
-        context.joker_state_manager.set_state(
-            joker.id(),
-            joker.initialize_state(&context)
-        );
+        context
+            .joker_state_manager
+            .set_state(joker.id(), joker.initialize_state(&context));
 
         // Play two hands without face cards to accumulate mult
         let hand1 = SelectHand::new(vec![
@@ -73,7 +73,7 @@ mod ride_the_bus_tests {
             Card::new(Rank::Two, Suit::Spade),
         ]);
         joker.on_hand_played(&mut context, &hand1);
-        
+
         let hand2 = SelectHand::new(vec![
             Card::new(Rank::Three, Suit::Heart),
             Card::new(Rank::Four, Suit::Spade),
@@ -99,12 +99,11 @@ mod ride_the_bus_tests {
         // Create stateful Ride the Bus joker
         let joker = create_ride_the_bus_stateful();
         let mut context = create_test_context();
-        
+
         // Initialize joker state
-        context.joker_state_manager.set_state(
-            joker.id(),
-            joker.initialize_state(&context)
-        );
+        context
+            .joker_state_manager
+            .set_state(joker.id(), joker.initialize_state(&context));
 
         // First hand without face cards
         let hand1 = SelectHand::new(vec![
@@ -136,12 +135,11 @@ mod ride_the_bus_tests {
         // Create stateful Ride the Bus joker
         let joker = create_ride_the_bus_stateful();
         let mut context = create_test_context();
-        
+
         // Initialize joker state
-        context.joker_state_manager.set_state(
-            joker.id(),
-            joker.initialize_state(&context)
-        );
+        context
+            .joker_state_manager
+            .set_state(joker.id(), joker.initialize_state(&context));
 
         // Build up some accumulated mult
         for _ in 0..3 {
@@ -179,12 +177,11 @@ mod ride_the_bus_tests {
         // Create stateful Ride the Bus joker
         let joker = create_ride_the_bus_stateful();
         let mut context = create_test_context();
-        
+
         // Initialize joker state
-        context.joker_state_manager.set_state(
-            joker.id(),
-            joker.initialize_state(&context)
-        );
+        context
+            .joker_state_manager
+            .set_state(joker.id(), joker.initialize_state(&context));
 
         // Build up accumulated mult
         for _ in 0..3 {
@@ -198,7 +195,7 @@ mod ride_the_bus_tests {
         // Score non-face cards - should not reset
         let ace = Card::new(Rank::Ace, Suit::Heart);
         joker.on_card_scored(&mut context, &ace);
-        
+
         let ten = Card::new(Rank::Ten, Suit::Spade);
         joker.on_card_scored(&mut context, &ten);
 
@@ -213,12 +210,11 @@ mod ride_the_bus_tests {
         // Create stateful Ride the Bus joker
         let joker = create_ride_the_bus_stateful();
         let mut context = create_test_context();
-        
+
         // Initialize joker state
-        context.joker_state_manager.set_state(
-            joker.id(),
-            joker.initialize_state(&context)
-        );
+        context
+            .joker_state_manager
+            .set_state(joker.id(), joker.initialize_state(&context));
 
         // Empty hand has no face cards, so should increment
         let empty_hand = SelectHand::new(vec![]);
@@ -232,12 +228,12 @@ mod ride_the_bus_tests {
 
     // Helper function to create test context
     fn create_test_context() -> GameContext<'static> {
-        use std::sync::{Arc, OnceLock};
         use crate::hand::Hand;
-        use crate::stage::{Stage, Blind};
         use crate::rank::HandRank;
+        use crate::stage::{Blind, Stage};
         use std::collections::HashMap;
-        
+        use std::sync::{Arc, OnceLock};
+
         static STAGE: Stage = Stage::Blind(Blind::Small);
         static HAND: OnceLock<Hand> = OnceLock::new();
         let hand = HAND.get_or_init(|| Hand::new(Vec::new()));
@@ -250,7 +246,7 @@ mod ride_the_bus_tests {
 
         static TEST_RNG: OnceLock<crate::rng::GameRng> = OnceLock::new();
         let rng = TEST_RNG.get_or_init(|| crate::rng::GameRng::for_testing(42));
-        
+
         GameContext {
             chips: 0,
             mult: 1,
@@ -292,59 +288,62 @@ mod ride_the_bus_tests {
 
         assert!(!has_face_cards); // Should have no face cards
     }
-    
+
     #[test]
     fn test_ride_the_bus_factory_compatibility() {
         // Test that the old factory function returns a stateful joker
         let joker = create_ride_the_bus();
         let mut context = create_test_context();
-        
+
         // Initialize joker state
-        context.joker_state_manager.set_state(
-            joker.id(),
-            joker.initialize_state(&context)
-        );
-        
+        context
+            .joker_state_manager
+            .set_state(joker.id(), joker.initialize_state(&context));
+
         // Should work the same as stateful version
         let hand = SelectHand::new(vec![Card::new(Rank::Two, Suit::Heart)]);
         let effect = joker.on_hand_played(&mut context, &hand);
         assert_eq!(effect.mult, 1);
-        
+
         // Score a face card and verify reset
         let king = Card::new(Rank::King, Suit::Spade);
         joker.on_card_scored(&mut context, &king);
-        
+
         let effect2 = joker.on_hand_played(&mut context, &hand);
         assert_eq!(effect2.mult, 1); // Should have reset
     }
-    
+
     #[test]
     fn test_ride_the_bus_state_persistence() {
         // Test that state persists correctly
         let joker = create_ride_the_bus_stateful();
         let mut context = create_test_context();
-        
+
         // Initialize and get initial state
         let initial_state = joker.initialize_state(&context);
-        context.joker_state_manager.set_state(joker.id(), initial_state.clone());
-        
+        context
+            .joker_state_manager
+            .set_state(joker.id(), initial_state.clone());
+
         // Play some hands to accumulate state
         let hand = SelectHand::new(vec![Card::new(Rank::Two, Suit::Heart)]);
         for _ in 0..3 {
             joker.on_hand_played(&mut context, &hand);
         }
-        
+
         // Get current state
         let current_state = context.joker_state_manager.get_state(joker.id()).unwrap();
         assert_eq!(current_state.accumulated_value, 3.0);
-        
+
         // Simulate saving and loading state
         let saved_state = current_state.clone();
-        
+
         // Create new context and restore state
         let mut new_context = create_test_context();
-        new_context.joker_state_manager.set_state(joker.id(), saved_state);
-        
+        new_context
+            .joker_state_manager
+            .set_state(joker.id(), saved_state);
+
         // Should continue from saved state
         let effect = joker.on_hand_played(&mut new_context, &hand);
         assert_eq!(effect.mult, 4); // 3 + 1


### PR DESCRIPTION
## Summary
- Fixes incorrect Ride the Bus joker implementation
- Converts from simple conditional joker to stateful implementation with accumulation/reset
- Implements proper game mechanics as described in issue #144

## Changes
### Implementation
- **Replaced ConditionalJoker with custom stateful implementation**
  - Uses `JokerStateManager` to track accumulated multiplier
  - Properly accumulates +1 mult for each hand without face cards
  - Resets to 0 when any face card (J, Q, K) is scored

### Code Quality
- **Applied TDD approach** - wrote comprehensive tests first
- **Clean code principles** - extracted helper methods for face card detection
- **SOLID compliance** - single responsibility, clean interfaces
- **Backward compatibility** - existing factory function now returns stateful version

### Testing
- **13 comprehensive tests** covering all behavior:
  - Accumulation without face cards
  - Reset on face card scoring (J, Q, K)
  - No increment when hand contains face cards
  - State persistence and restoration
  - Factory function compatibility
  - Edge cases (empty hands, all face cards, etc.)

## Test Results
All tests passing:
```
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 553 filtered out
```

Full test suite also passes with no regressions.

## Files Changed
- `core/src/joker/hand_composition_jokers.rs` - Stateful implementation
- `core/src/joker/hand_composition_tests.rs` - Comprehensive test coverage

Closes #144

🤖 Generated with [Claude Code](https://claude.ai/code)