### PR TITLE
Fix Square Joker implementation to use scaling behavior

### DIFF
--- a/core/src/joker_factory.rs
+++ b/core/src/joker_factory.rs
@@ -1,5 +1,6 @@
 use crate::joker::{Joker, JokerId, JokerRarity};
 use crate::joker_impl::*;
+use crate::scaling_joker_custom;
 use crate::special_jokers::*;
 use crate::static_joker_factory::StaticJokerFactory;
 
@@ -41,7 +42,9 @@ impl JokerFactory {
             JokerId::RedCard => Some(StaticJokerFactory::create_red_card()),
             JokerId::BlueJoker => Some(StaticJokerFactory::create_blue_joker()),
             JokerId::FacelessJoker => Some(StaticJokerFactory::create_faceless_joker()),
-            JokerId::Square => Some(StaticJokerFactory::create_square()),
+            JokerId::Square => {
+                scaling_joker_custom::get_custom_scaling_joker_by_id(JokerId::Square)
+            }
             JokerId::Walkie => Some(StaticJokerFactory::create_walkie()),
 
             // Placeholder jokers with TODO comments

--- a/core/src/static_joker_factory.rs
+++ b/core/src/static_joker_factory.rs
@@ -403,33 +403,7 @@ impl StaticJokerFactory {
         )
     }
 
-    /// Create Square (Number cards give +4 Chips when scored)
-    pub fn create_square() -> Box<dyn Joker> {
-        Box::new(
-            StaticJoker::builder(
-                JokerId::Square,
-                "Square",
-                "Number cards (2, 3, 4, 5, 6, 7, 8, 9, 10) give +4 Chips when scored",
-            )
-            .rarity(JokerRarity::Common)
-            .cost(3)
-            .chips(4)
-            .condition(StaticCondition::AnyRankScored(vec![
-                Value::Two,
-                Value::Three,
-                Value::Four,
-                Value::Five,
-                Value::Six,
-                Value::Seven,
-                Value::Eight,
-                Value::Nine,
-                Value::Ten,
-            ]))
-            .per_card()
-            .build()
-            .expect("Valid joker configuration"),
-        )
-    }
+    // Square Joker removed - now implemented as scaling joker in scaling_joker_impl.rs
 
     /// Create Walkie (+10 Chips and +4 Mult if hand contains Straight)
     pub fn create_walkie() -> Box<dyn Joker> {

--- a/core/tests/test_additional_static_jokers.rs
+++ b/core/tests/test_additional_static_jokers.rs
@@ -52,19 +52,7 @@ fn test_faceless_joker() {
     assert_eq!(joker.cost(), 3);
 }
 
-#[test]
-#[ignore = "EMERGENCY DISABLE: GameContext default issues - tracked for post-emergency fix"]
-fn test_square_joker() {
-    let joker = StaticJokerFactory::create_square();
-    assert_eq!(joker.id(), JokerId::Square);
-    assert_eq!(joker.name(), "Square");
-    assert_eq!(
-        joker.description(),
-        "Number cards (2, 3, 4, 5, 6, 7, 8, 9, 10) give +4 Chips when scored"
-    );
-    assert_eq!(joker.rarity(), JokerRarity::Common);
-    assert_eq!(joker.cost(), 3);
-}
+// Square Joker removed - now implemented as scaling joker in scaling_joker_impl.rs
 
 #[test]
 #[ignore = "EMERGENCY DISABLE: GameContext default issues - tracked for post-emergency fix"]

--- a/core/tests/test_square_joker.rs
+++ b/core/tests/test_square_joker.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+mod square_joker_tests {
+    use balatro_rs::{
+        joker::{JokerId, JokerRarity},
+        joker_factory::JokerFactory,
+    };
+
+    #[test]
+    fn test_square_joker_basic_properties() {
+        let joker = JokerFactory::create(JokerId::Square).expect("Square joker should exist");
+        assert_eq!(joker.id(), JokerId::Square);
+        assert_eq!(joker.name(), "Square Joker");
+        assert_eq!(joker.description(), "+4 Chips per 4-card hand played");
+        assert_eq!(joker.rarity(), JokerRarity::Common);
+    }
+
+    #[test]
+    fn test_square_joker_is_scaling() {
+        // Verify that Square joker is now using the scaling implementation
+        let joker = JokerFactory::create(JokerId::Square).expect("Square joker should exist");
+
+        // The fact that it has the correct description confirms it's the scaling version
+        // The static version had description: "Number cards (2, 3, 4, 5, 6, 7, 8, 9, 10) give +4 Chips when scored"
+        // The scaling version has description: "+4 Chips per 4-card hand played"
+        assert_ne!(
+            joker.description(),
+            "Number cards (2, 3, 4, 5, 6, 7, 8, 9, 10) give +4 Chips when scored"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed Square Joker to use the correct scaling implementation
- Square Joker now gains +4 chips permanently each time a hand with exactly 4 cards is played
- Removed incorrect static implementation that gave +4 chips to number cards (2-10)

## Details
The Square Joker was incorrectly implemented as a static joker. According to the corrected issue #149, Square Joker should be a scaling joker with the behavior: "This Joker gains +4 Chips if played hand has exactly 4 cards (Currently 0 Chips)". Every time a hand is played with exactly 4 cards (even if they don't score), the joker permanently gains a 4 chip bonus.

The scaling implementation was already present in `scaling_joker_impl.rs` with the correct behavior, so this PR:
1. Removes the incorrect static Square Joker from `static_joker_factory.rs`
2. Updates `JokerFactory::create()` to use the scaling Square Joker
3. Updates tests to verify the correct behavior

## Test plan
- [x] All existing tests pass with `cargo test --all`
- [x] Added specific tests for Square Joker in `test_square_joker.rs`
- [x] Verified Square Joker has correct name: "Square Joker"
- [x] Verified Square Joker has correct description: "+4 Chips per 4-card hand played"
- [x] Verified Square Joker is Common rarity
- [x] Zero warnings with `cargo clippy --all -- -D warnings`
- [x] Code formatted with `cargo fmt --all`

Fixes #149

🤖 Generated with [Claude Code](https://claude.ai/code)