### PR TITLE
🚨 HOTFIX: [P0] Fix missing ProcessResult fields causing build failure

### DIFF
--- a/core/src/joker/resource_chips_jokers.rs
+++ b/core/src/joker/resource_chips_jokers.rs
@@ -442,7 +442,9 @@ impl JokerGameplay for ScaryFaceJoker {
         ProcessResult {
             chips_added,
             mult_added: 0.0,
+            mult_multiplier: 1.0,
             retriggered: false,
+            message: None,
         }
     }
 


### PR DESCRIPTION
## Emergency Fix for Production Build Failure

### Impact
- **Severity**: P0 (Critical)
- **Affected Systems**: Core build system - unable to compile
- **User Impact**: All development blocked

### Root Cause
The ScaryFaceJoker implementation was missing two required fields in its ProcessResult struct initialization:
- `mult_multiplier: f64`
- `message: Option<String>`

This was causing a compilation error that prevented the entire project from building.

### Solution
Added the missing fields to the ProcessResult initializer:
- `mult_multiplier: 1.0` (default value, no multiplier effect)
- `message: None` (no custom message needed)

### Testing
- [x] Build now completes successfully
- [x] All existing tests pass
- [x] Manual verification completed

### Deployment
- **Target Environment**: Main branch
- **Deployment Window**: IMMEDIATE
- **Rollback Strategy**: Revert commit if any issues arise

### Emergency Response Timeline
- Build failure detected
- Root cause identified in resource_chips_jokers.rs:442
- Fix applied and tested
- Emergency worktree created following protocol
- PR created for immediate review

cc @spencerduncan