### PR TITLE
fix: Implement missing Misprint joker in JokerFactory (#621)

### DIFF
--- a/core/src/joker/basic_xmult_jokers.rs
+++ b/core/src/joker/basic_xmult_jokers.rs
@@ -519,7 +519,7 @@ impl JokerGameplay for BloodstoneJoker {
     }
 }
 
-/// Misprint Joker - X1 to X23 Mult (random each hand)
+/// Misprint Joker - +0 to +23 Mult (random each hand)
 #[derive(Debug, Clone)]
 pub struct MisprintJoker {
     id: JokerId,
@@ -540,9 +540,9 @@ impl MisprintJoker {
         Self {
             id: JokerId::Misprint,
             name: "Misprint".to_string(),
-            description: "X1 to X23 Mult (random each hand)".to_string(),
+            description: "+0 to +23 Mult (random each hand)".to_string(),
             rarity: JokerRarity::Common,
-            cost: 4,
+            cost: 3, // Common jokers cost 3
         }
     }
 }
@@ -596,12 +596,12 @@ impl Joker for MisprintJoker {
     }
 
     fn on_hand_played(&self, context: &mut GameContext, _hand: &SelectHand) -> JokerEffect {
-        // Use game RNG to generate random multiplier between 1 and 23
-        let multiplier = context.rng.gen_range(1..=23) as f64;
+        // Use game RNG to generate random mult bonus between 0 and 23
+        let mult_bonus = context.rng.gen_range(0..=23);
 
         JokerEffect::new()
-            .with_mult_multiplier(multiplier)
-            .with_message(format!("Misprint: X{multiplier} Mult"))
+            .with_mult(mult_bonus)
+            .with_message(format!("Misprint: +{mult_bonus} Mult"))
     }
 }
 
@@ -744,7 +744,11 @@ mod tests {
         // Test identity
         assert_eq!(misprint.joker_type(), "misprint");
         assert_eq!(JokerIdentity::name(&misprint), "Misprint");
-        assert_eq!(misprint.base_cost(), 4);
+        assert_eq!(
+            Joker::description(&misprint),
+            "+0 to +23 Mult (random each hand)"
+        );
+        assert_eq!(misprint.base_cost(), 3); // Common jokers cost 3
 
         // Test can trigger
         let stage = Stage::Blind(Blind::Small);
@@ -769,5 +773,64 @@ mod tests {
         };
 
         assert!(misprint.can_trigger(&stage, &context));
+    }
+
+    #[test]
+    fn test_misprint_joker_random_mult() {
+        use crate::hand::SelectHand;
+        use crate::joker::{GameContext, Joker};
+        use crate::rng::GameRng;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let misprint = MisprintJoker::new();
+        let mut rng = GameRng::new(crate::rng::RngMode::Testing(42));
+
+        // Test that Misprint generates mult values in the correct range (0-23)
+        let mut found_values = std::collections::HashSet::new();
+
+        for _ in 0..100 {
+            let mut context = GameContext {
+                chips: 0,
+                mult: 0,
+                money: 0,
+                ante: 1,
+                round: 1,
+                stage: &crate::stage::Stage::Blind(crate::stage::Blind::Small),
+                hands_played: 0,
+                hands_remaining: 3.0,
+                discards_used: 0,
+                jokers: &[],
+                hand: &crate::hand::Hand::new(vec![]),
+                discarded: &[],
+                joker_state_manager: &Arc::new(crate::joker_state::JokerStateManager::new()),
+                hand_type_counts: &HashMap::new(),
+                cards_in_deck: 52,
+                stone_cards_in_deck: 0,
+                steel_cards_in_deck: 0,
+                rng: &mut rng,
+            };
+
+            let hand = SelectHand::new(vec![]);
+            let effect = misprint.on_hand_played(&mut context, &hand);
+
+            // Verify mult is in range 0-23
+            assert!(effect.mult >= 0);
+            assert!(effect.mult <= 23);
+            found_values.insert(effect.mult);
+
+            // Verify mult_multiplier is default (1.0, not used)
+            assert_eq!(effect.mult_multiplier, 1.0);
+
+            // Verify message format
+            let expected_message = format!("Misprint: +{} Mult", effect.mult);
+            assert_eq!(effect.message, Some(expected_message));
+        }
+
+        // We should have found multiple different values in 100 trials
+        assert!(
+            found_values.len() > 1,
+            "Misprint should generate different random values"
+        );
     }
 }

--- a/core/src/joker_factory.rs
+++ b/core/src/joker_factory.rs
@@ -1,6 +1,7 @@
 use crate::joker::basic_economy_jokers::{
     DelayedGratificationJoker, GiftCardJoker, RocketJoker, ToTheMoonJoker,
 };
+use crate::joker::basic_xmult_jokers::create_misprint_joker;
 use crate::joker::four_fingers::FourFingersJoker;
 use crate::joker::multiplicative_jokers::AcrobatJoker;
 use crate::joker::resource_chips_jokers::ScaryFaceJoker;
@@ -38,6 +39,9 @@ impl JokerFactory {
             JokerId::CleverJoker => Some(Box::new(CleverJoker)),
             JokerId::DeviousJoker => Some(Box::new(DeviousJoker)),
             JokerId::CraftyJoker => Some(Box::new(CraftyJoker)),
+
+            // Basic xmult jokers
+            JokerId::Misprint => Some(create_misprint_joker()),
 
             // Money-based conditional jokers
             JokerId::BusinessCard => Some(Box::new(BusinessCard)),
@@ -161,6 +165,8 @@ impl JokerFactory {
                 CleverJoker,
                 DeviousJoker,
                 CraftyJoker,
+                // Basic xmult jokers
+                Misprint,
                 // Money-based conditional jokers
                 BusinessCard,
                 EggJoker,
@@ -262,6 +268,8 @@ impl JokerFactory {
             CleverJoker,
             DeviousJoker,
             CraftyJoker,
+            // Basic xmult jokers
+            Misprint,
             // Money-based conditional jokers
             BusinessCard,
             EggJoker,
@@ -357,6 +365,19 @@ mod tests {
         let runner = JokerFactory::create(JokerId::Runner);
         assert!(runner.is_some());
         assert_eq!(runner.unwrap().id(), JokerId::Runner);
+
+        // Test Misprint joker
+        let misprint = JokerFactory::create(JokerId::Misprint);
+        assert!(misprint.is_some());
+        let misprint_joker = misprint.unwrap();
+        assert_eq!(misprint_joker.id(), JokerId::Misprint);
+        assert_eq!(misprint_joker.name(), "Misprint");
+        assert_eq!(
+            misprint_joker.description(),
+            "+0 to +23 Mult (random each hand)"
+        );
+        assert_eq!(misprint_joker.rarity(), JokerRarity::Common);
+        assert_eq!(misprint_joker.cost(), 3);
     }
 
     #[test]
@@ -394,6 +415,7 @@ mod tests {
         assert!(common_jokers.contains(&JokerId::Banner));
         assert!(common_jokers.contains(&JokerId::AbstractJoker));
         assert!(common_jokers.contains(&JokerId::ScaryFace));
+        assert!(common_jokers.contains(&JokerId::Misprint));
 
         let uncommon_jokers = JokerFactory::get_by_rarity(JokerRarity::Uncommon);
         assert!(uncommon_jokers.contains(&JokerId::BlueJoker));
@@ -413,6 +435,7 @@ mod tests {
         assert!(implemented.contains(&JokerId::Runner));
         assert!(implemented.contains(&JokerId::AbstractJoker));
         assert!(implemented.contains(&JokerId::ScaryFace));
+        assert!(implemented.contains(&JokerId::Misprint));
 
         // AbstractJoker is now properly implemented and included above
         // Note: Placeholder jokers (HalfJoker, Banner)


### PR DESCRIPTION
## Summary

Implements the missing Misprint joker that was defined in the JokerId enum but completely absent from JokerFactory, resolving issue #621.

**Key Changes:**
- ✅ Fixed Misprint implementation to use additive mult (+0 to +23) instead of multiplicative mult per joker.json spec
- ✅ Added JokerId::Misprint case to JokerFactory::create() method to enable joker instantiation 
- ✅ Added Misprint to Common rarity and implemented jokers lists
- ✅ Updated joker description and cost to match specification
- ✅ Added comprehensive tests for factory integration and random behavior
- ✅ All tests passing with CI validation

**Technical Details:**
- **Behavior**: Provides +0 to +23 additive mult randomly each hand
- **Rarity**: Common (cost: 3 coins)
- **Implementation**: Uses GameRng for secure random generation
- **Testing**: Comprehensive tests verify range, randomness, and factory integration

## Test Plan

- [x] Misprint joker can be created via JokerFactory::create()
- [x] Joker appears in Common rarity lists  
- [x] Joker appears in implemented jokers lists
- [x] Random mult generation works correctly (0-23 range)
- [x] Factory tests verify joker properties (name, description, cost, rarity)
- [x] All existing tests continue to pass
- [x] Precommit checks pass (formatting, linting, security)

🤖 Generated with [Claude Code](https://claude.ai/code)