### PR TITLE
HOTFIX [P1]: Fix CI Pipeline - Upgrade GitHub Actions artifact v3 to v4

### DIFF
--- a/.github/workflows/test-enhanced.yml
+++ b/.github/workflows/test-enhanced.yml
@@ -50,19 +50,19 @@ jobs:
           components: rustfmt, clippy, llvm-tools-preview
 
       - name: Cache cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.rust }}
           path: |
@@ -110,7 +110,7 @@ jobs:
           verbose: true
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage-report/
@@ -140,7 +140,7 @@ jobs:
         run: cargo install cargo-criterion
 
       - name: Cache benchmark data
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target/criterion
           key: ${{ runner.os }}-benchmark-${{ github.sha }}
@@ -189,7 +189,7 @@ jobs:
           "
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
           path: |
@@ -223,7 +223,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nextest-report-partition-${{ matrix.partition }}
           path: target/nextest/ci/junit.xml
@@ -236,7 +236,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Generate summary report
         run: |


### PR DESCRIPTION
## Emergency Fix for Production CI Pipeline

### Impact
- **Severity**: P1 - Critical Infrastructure Failure
- **Affected Systems**: Enhanced Testing Pipeline, all CI/CD workflows
- **User Impact**: 100% CI failure rate, blocking all development

### Root Cause
GitHub is deprecating `actions/upload-artifact@v3` and `actions/download-artifact@v3`. During brownout periods (active now through January 30, 2025), these actions automatically fail with:
```
This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3
```

### Solution
Upgraded all artifact and cache actions from v3 to v4:
- `actions/upload-artifact@v3` → `@v4`
- `actions/download-artifact@v3` → `@v4`
- `actions/cache@v3` → `@v4` (for consistency)

### Testing
- [x] Workflow file syntax validated
- [x] YAML parsing confirmed
- [x] Pre-commit hooks passed
- [ ] CI pipeline will validate on merge

The v4 actions are drop-in replacements with identical API. No configuration changes required beyond version update.

### Deployment
- **Target Environment**: GitHub Actions CI/CD
- **Deployment Window**: IMMEDIATE
- **Rollback Strategy**: Revert commit if issues arise

### Timeline
- **Issue Detected**: 3:19 AM UTC (Enhanced Testing Pipeline failure)
- **Root Cause Identified**: GitHub Actions v3 deprecation brownout
- **Fix Applied**: 3:30 AM UTC
- **Resolution Expected**: Upon merge

### References
- [GitHub Actions v3 Deprecation Notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
- Final deprecation date: January 30, 2025

cc @spencerduncan - IMMEDIATE merge required to restore CI functionality